### PR TITLE
Internal command execution and masking sensitive values

### DIFF
--- a/.env-select.toml
+++ b/.env-select.toml
@@ -1,4 +1,5 @@
 [vars]
+PASSWORD = ["hunter2", {command = "echo secret_password | base64", sensitive = true}]
 TEST_VARIABLE = ["abc", {command = "echo def"}]
 
 [apps.server]

--- a/USAGE.md
+++ b/USAGE.md
@@ -157,12 +157,12 @@ You can define variables whose values are provided dynamically, by specific a co
 
 ```toml
 [apps.db]
-dev = {DATABASE = "dev", DB_USER = "root", DB_PASSWORD = {command = "cat password.txt"}}
+dev = {DATABASE = "dev", DB_USER = "root", DB_PASSWORD = {command = "cat password.txt", sensitive = true}}
 ```
 
-When the `dev` profile is selected for the `db` app, the `DB_PASSWORD` value will be loaded from the file `password.txt`.
+When the `dev` profile is selected for the `db` app, the `DB_PASSWORD` value will be loaded from the file `password.txt`. The `sensitive` field is an _optional_ value that will mask the value in informational logging.
 
-Note that **the command evaluation is done by your shell**, _not_ by `env-select`. This means you can use aliases and functions defined in your shell as commands.
+Note that **the command evaluation is done by your shell**. This means you can use aliases and functions defined in your shell as commands.
 
 ### Disjoint Profiles
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -4,14 +4,14 @@
 
 env-select operates with a few different building blocks:
 
-- Value
-- Variable Mapping
-- Profile
-- Application
+- [Value Source](#value-source)
+- [Variable Mapping](#variable-mapping)
+- [Profile](#profile)
+- [Application](#application)
 
-### Value
+### Value Source
 
-A value is a means of deriving a string for the shell. Typically this is just a literal string: `"abc"`, but it can also be a command that will be evaluated to a string at runtime.
+A value source is a means of deriving a string for the shell. Typically this is just a literal string: `"abc"`, but it can also be a command that will be evaluated to a string at runtime.
 
 ```sh
 dev # Literal
@@ -20,7 +20,7 @@ $(echo prd) # Command
 
 ### Variable Mapping
 
-A key and a value. Variables can either be selected independently (via the `vars` key in the config) or be part of a profile with other variables.
+A key and a value source. Variables can either be selected independently (via the `vars` key in the config) or be part of a profile with other variables.
 
 ```sh
 SERVICE1=dev
@@ -112,10 +112,10 @@ dev also-dev
 Configuration is defined in [TOML](https://toml.io/en/). There are two main tables in the config, each defined by a fixed key:
 
 - Single variables, under the `vars` key
-  - Each table entry is a mapping from `VARIABLE_NAME` to a list of possible values
+  - Each table entry is a mapping from `VARIABLE_NAME` to a list of possible value sources
 - [Applications](#application), under the `apps` key
   - Sub-tables define each [profiles](#profile)
-  - Each profile consists of a mapping of `VARIABLE = "value"`
+  - Each profile consists of a mapping of `VARIABLE = <value source>`
 
 Let's see this in action:
 
@@ -153,14 +153,14 @@ VAR5 = "no"
 
 ### Dynamic Values
 
-You can define variables whose values are provided dynamically, by specific a command to execute rather than a static value. This allows you to provide values that can change over time, or secrets that you don't want appearing in the file. For example:
+You can define variables whose values are provided dynamically, by specifying a command to execute rather than a static value. This allows you to provide values that can change over time, or secrets that you don't want appearing in the file. For example:
 
 ```toml
 [apps.db]
 dev = {DATABASE = "dev", DB_USER = "root", DB_PASSWORD = {command = "cat password.txt", sensitive = true}}
 ```
 
-When the `dev` profile is selected for the `db` app, the `DB_PASSWORD` value will be loaded from the file `password.txt`. The `sensitive` field is an _optional_ value that will mask the value in informational logging.
+When the `dev` profile is selected for the `db` app, the `DB_PASSWORD` value will be loaded from the file `password.txt`. The `sensitive` field is an _optional_ field that will mask the value in informational logging.
 
 Note that **the command evaluation is done by your shell**. This means you can use aliases and functions defined in your shell as commands.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -129,6 +129,7 @@ pub struct Profile {
 /// An object should be treated as other variants, based on the field structure.
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, Hash, PartialEq)]
 #[serde(untagged)]
+// TODO rename to ValueSource?
 pub enum Value {
     /// A plain string value
     Literal(String),

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,7 +23,7 @@ pub struct Config {
     /// an ordered set here so the ordering from the user's file(s) is
     /// maintained, but without duplicates.
     #[serde(default, rename = "vars")]
-    pub variables: IndexMap<String, IndexSet<Value>>,
+    pub variables: IndexMap<String, IndexSet<ValueSource>>,
 
     /// A set of named applications (as in, a use case, purpose, etc.). An
     /// application typically has one or more variables that control it, and
@@ -118,7 +118,7 @@ pub struct Application {
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Eq, PartialEq)]
 pub struct Profile {
     #[serde(flatten)]
-    pub variables: IndexMap<String, Value>,
+    pub variables: IndexMap<String, ValueSource>,
 }
 
 /// A variable's value. Can be a literal value, or an embedded command, which
@@ -129,8 +129,7 @@ pub struct Profile {
 /// An object should be treated as other variants, based on the field structure.
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, Hash, PartialEq)]
 #[serde(untagged)]
-// TODO rename to ValueSource?
-pub enum Value {
+pub enum ValueSource {
     /// A plain string value
     Literal(String),
     /// A command that will be executed at runtime to get the variable's value.
@@ -142,11 +141,11 @@ pub enum Value {
     },
 }
 
-impl Display for Value {
+impl Display for ValueSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Value::Literal(value) => write!(f, "{value}"),
-            Value::Command { command, .. } => write!(f, "`{command}`"),
+            ValueSource::Literal(value) => write!(f, "{value}"),
+            ValueSource::Command { command, .. } => write!(f, "`{command}`"),
         }
     }
 }
@@ -203,9 +202,9 @@ mod tests {
     use super::*;
     use indexmap::{indexmap, indexset};
 
-    impl From<&str> for Value {
+    impl From<&str> for ValueSource {
         fn from(s: &str) -> Self {
-            Value::Literal(s.into())
+            ValueSource::Literal(s.into())
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -135,14 +135,18 @@ pub enum Value {
     Literal(String),
     /// A command that will be executed at runtime to get the variable's value.
     /// Useful for values that change, secrets, etc.
-    Command { command: String },
+    Command {
+        command: String,
+        #[serde(default)]
+        sensitive: bool,
+    },
 }
 
 impl Display for Value {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Value::Literal(value) => write!(f, "{value}"),
-            Value::Command { command } => write!(f, "`{command}`"),
+            Value::Command { command, .. } => write!(f, "`{command}`"),
         }
     }
 }

--- a/src/console.rs
+++ b/src/console.rs
@@ -1,4 +1,4 @@
-use crate::config::{Application, Profile, Value};
+use crate::config::{Application, Profile, ValueSource};
 use anyhow::bail;
 use atty::Stream;
 use dialoguer::{theme::ColorfulTheme, Select};
@@ -13,8 +13,8 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 /// value. Returns `Ok(None)` iff the user quits out of the prompt.
 pub fn prompt_variable<'a>(
     variable: &str,
-    options: &'a IndexSet<Value>,
-) -> anyhow::Result<&'a Value> {
+    options: &'a IndexSet<ValueSource>,
+) -> anyhow::Result<&'a ValueSource> {
     let theme = ColorfulTheme::default();
     // Show a prompt to ask the user which value to use
     let chosen_index = Select::with_theme(&theme)

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use crate::{config::Config, export::Exporter, shell::Shell};
 use anyhow::anyhow;
 use clap::{Parser, Subcommand};
 use log::{error, LevelFilter};
-use std::{iter, process::ExitCode};
+use std::{iter, path::PathBuf, process::ExitCode};
 
 const BINARY_NAME: &str = env!("CARGO_BIN_NAME");
 
@@ -20,10 +20,10 @@ struct Args {
     #[command(subcommand)]
     command: Commands,
 
-    /// Type of shell being exported to. If omitted, will be auto-detected from
-    /// the $SHELL variable
+    /// Path to the shell binary in use. If omitted, it will be auto-detected
+    /// from the $SHELL variable. Supported shell types: bash, zsh, fish
     #[clap(short, long)]
-    shell: Option<Shell>,
+    shell_path: Option<PathBuf>,
 
     /// Increase output verbosity, for debugging. Supports up to -vv
     #[clap(short, long, action = clap::ArgAction::Count)]
@@ -104,8 +104,8 @@ fn run(args: &Args) -> anyhow::Result<()> {
     })?;
 
     let config = Config::load()?;
-    let shell = match args.shell {
-        Some(shell) => shell,
+    let shell = match &args.shell_path {
+        Some(shell_path) => Shell::from_path(shell_path)?,
         None => Shell::detect()?,
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,10 +83,11 @@ fn main() -> ExitCode {
             // Print the error. Most of the time this is a user error, but this
             // will also handle system errors or application bugs. The user
             // should pass -v to get a stack trace for debugging.
+            // https://docs.rs/anyhow/1.0.71/anyhow/struct.Error.html#display-representations
             if args.verbose > 0 {
-                error!("{error}\n{}", error.backtrace());
+                error!("{error:#}\n{}", error.backtrace());
             } else {
-                error!("{error}");
+                error!("{error:#}");
             }
             ExitCode::FAILURE
         }
@@ -105,7 +106,7 @@ fn run(args: &Args) -> anyhow::Result<()> {
 
     let config = Config::load()?;
     let shell = match &args.shell_path {
-        Some(shell_path) => Shell::from_path(shell_path)?,
+        Some(shell_path) => Shell::from_path(shell_path.into())?,
         None => Shell::detect()?,
     };
 
@@ -137,7 +138,7 @@ fn run(args: &Args) -> anyhow::Result<()> {
                 .get_suggestion_error("No variable or application provided.")),
         },
         Commands::Show => {
-            println!("Shell: {shell}");
+            println!("Shell: {}", shell.path.to_string_lossy());
             println!();
             println!("{}", toml::to_string(&config)?);
             Ok(())

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,20 +1,28 @@
-use crate::{config::Value, console, export::Environment};
-use anyhow::anyhow;
+use crate::{console, export::Environment};
+use anyhow::{anyhow, bail, Context};
 use std::{
     env,
     ffi::OsStr,
     fmt::{Display, Formatter},
     fs,
-    path::{Path, PathBuf},
+    path::PathBuf,
+    process::Command,
 };
 
 const BASH_WRAPPER: &str = include_str!("../shells/es.bash");
 const ZSH_WRAPPER: &str = include_str!("../shells/es.zsh");
 const FISH_WRAPPER: &str = include_str!("../shells/es.fish");
 
-/// A known shell type. We can use this to export variables.
+/// A pointer to a specific shell binary
+#[derive(Clone, Debug)]
+pub struct Shell {
+    pub path: PathBuf,
+    pub type_: ShellType,
+}
+
+/// A supported kind of shell
 #[derive(Copy, Clone, Debug)]
-pub enum Shell {
+pub enum ShellType {
     Bash,
     Zsh,
     Fish,
@@ -25,39 +33,40 @@ impl Shell {
         // The $SHELL variable should give us the path to the shell, which we
         // can use to figure out which shell it is
         let shell_path = PathBuf::from(env::var("SHELL")?);
-        Self::from_path(&shell_path)
+        Self::from_path(shell_path)
     }
 
     /// Load the shell type from the given shell binary path. This will check
     /// the type of the shell, as well as ensure that the file exists so it can
     /// be invoked later if necessary.
-    pub fn from_path(path: &Path) -> anyhow::Result<Self> {
-        let file_metadata = fs::metadata(path)?;
+    pub fn from_path(path: PathBuf) -> anyhow::Result<Self> {
+        let file_metadata = fs::metadata(&path)?;
         if file_metadata.is_file() {
             let shell_name = path.file_name().and_then(OsStr::to_str).ok_or(
-                anyhow!("Failed to read shell type from path: {:?}", path),
+                anyhow!("Failed to read shell type from path: {path:?}"),
             )?;
-            match shell_name {
-                "bash" => Ok(Self::Bash),
-                "zsh" => Ok(Self::Zsh),
-                "fish" => Ok(Self::Fish),
-                other => Err(anyhow!("Unsupported shell type {other}")),
-            }
+            let shell_type = match shell_name {
+                "bash" => ShellType::Bash,
+                "zsh" => ShellType::Zsh,
+                "fish" => ShellType::Fish,
+                other => bail!("Unsupported shell type {other}"),
+            };
+            Ok(Self {
+                path,
+                type_: shell_type,
+            })
         } else {
-            Err(anyhow!(
-                "Shell path {} is not a file",
-                path.to_string_lossy()
-            ))
+            Err(anyhow!("Shell path {path:?} is not a file"))
         }
     }
 
     /// Print a valid shell script that will initialize the `es` wrapper as
     /// well as whatever other initialization is needed.
     pub fn print_init_script(&self) -> anyhow::Result<()> {
-        let wrapper_src = match self {
-            Self::Bash => BASH_WRAPPER,
-            Self::Zsh => ZSH_WRAPPER,
-            Self::Fish => FISH_WRAPPER,
+        let wrapper_src = match self.type_ {
+            ShellType::Bash => BASH_WRAPPER,
+            ShellType::Zsh => ZSH_WRAPPER,
+            ShellType::Fish => FISH_WRAPPER,
         };
 
         println!("{wrapper_src}");
@@ -76,45 +85,58 @@ impl Shell {
             .iter()
             .map(|(variable, value)| {
                 // Generate a shell command to export the variable
-                let value = self.value_to_string(value);
-                match self {
+                match self.type_ {
                     // Single quotes are needed to prevent injection
-                    // vulnerabilities. Quotes on the value
-                    // are applied by value_to_string, as necessary
-                    Self::Bash | Self::Zsh => {
-                        format!("export '{variable}'={value}")
+                    // vulnerabilities.
+                    // TODO escape inner single quotes
+                    ShellType::Bash | ShellType::Zsh => {
+                        format!("export '{variable}'='{value}'")
                     }
-                    Self::Fish => format!("set -gx '{variable}' {value}"),
+                    ShellType::Fish => {
+                        format!("set -gx '{variable}' '{value}'")
+                    }
                 }
             })
             .collect::<Vec<_>>()
             .join("\n")
     }
 
-    /// Map a value to a string that can be processed by the shell. Either a
-    /// literal value or a subshell command to get a dynamic value.
-    fn value_to_string(&self, value: &Value) -> String {
-        match (self, value) {
-            // Include single quotes to prevent accidental injection
-            (_, Value::Literal(value)) => format!("'{value}'"),
-            // Unfortunately no way around injection on these, since it _is_ an
-            // injection
-            (Self::Bash | Self::Zsh, Value::Command { command }) => {
-                format!("\"$({command})\"")
-            }
-            (Self::Fish, Value::Command { command }) => {
-                format!("({command})")
-            }
+    /// Execute a command in this shell, and return the stdout value. We execute
+    /// within the shell, rather than directly, so the user can use aliases,
+    /// piping, and other features from their shell.
+    pub fn execute(&self, command: &str) -> anyhow::Result<String> {
+        let output = Command::new(&self.path)
+            .args(["-c", command])
+            .output()
+            .with_context(|| format!("Error executing command `{command}`"))?;
+
+        // TODO Replace with ExitStatus::exit_ok
+        // https://github.com/rust-lang/rust/issues/84908
+        if output.status.success() {
+            Ok(String::from_utf8(output.stdout)
+                .context("Error decoding output for command `{command}`")?
+                .trim_end()
+                .to_string())
+        } else {
+            Err(anyhow!(
+                "`{}` failed with exit code {}",
+                command,
+                output
+                    .status
+                    .code()
+                    .map(|code| code.to_string())
+                    .unwrap_or_else(|| "unknown".into())
+            ))
         }
     }
 }
 
-impl Display for Shell {
+impl Display for ShellType {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Shell::Bash => write!(f, "bash"),
-            Shell::Zsh => write!(f, "zsh"),
-            Shell::Fish => write!(f, "fish"),
+            Self::Bash => write!(f, "bash"),
+            Self::Zsh => write!(f, "zsh"),
+            Self::Fish => write!(f, "fish"),
         }
     }
 }

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -76,29 +76,24 @@ impl Shell {
         Ok(())
     }
 
-    /// Get the shell command(s) that will configure the environment to a
+    /// Print the shell command(s) that will configure the environment to a
     /// particular set of key=value pairs for this shell type. This command
     /// can later be piped to the source command to apply it.
-    pub fn export(&self, environment: &Environment) -> String {
-        environment
-            .0
-            .iter()
-            .map(|(variable, value)| {
-                // Generate a shell command to export the variable
-                match self.type_ {
-                    // Single quotes are needed to prevent injection
-                    // vulnerabilities.
-                    // TODO escape inner single quotes
-                    ShellType::Bash | ShellType::Zsh => {
-                        format!("export '{variable}'='{value}'")
-                    }
-                    ShellType::Fish => {
-                        format!("set -gx '{variable}' '{value}'")
-                    }
+    pub fn export(&self, environment: &Environment) {
+        for (variable, value) in environment.iter_unmasked() {
+            // Generate a shell command to export the variable
+            match self.type_ {
+                // Single quotes are needed to prevent injection
+                // vulnerabilities.
+                // TODO escape inner single quotes
+                ShellType::Bash | ShellType::Zsh => {
+                    println!("export '{variable}'='{value}'")
                 }
-            })
-            .collect::<Vec<_>>()
-            .join("\n")
+                ShellType::Fish => {
+                    println!("set -gx '{variable}' '{value}'")
+                }
+            }
+        }
     }
 
     /// Execute a command in this shell, and return the stdout value. We execute


### PR DESCRIPTION
- Dynamic commands are now executed within the scope of `env-select`. We'll spawn a subprocess of *the shell* (NOT the command directly), then read its output
  - This allows us to print exported values to the user, which is helpful. It also gives us a bit more control over command resolution, and prevents weird bugs around command string templating
- Added `sensitive` option to dynamic commands, to mask the output in informational logging
- Renamed `Value` to `ValueSource` and updated the docs accordingly
- Replaced `--shell` with `--shell-path`, because `env-select` needs the full path to the shell to unambiguously execute subprocess shell commands