### PR TITLE
Support native commands

### DIFF
--- a/.env-select.toml
+++ b/.env-select.toml
@@ -1,6 +1,6 @@
 [vars]
-PASSWORD = ["hunter2", {command = "echo secret_password | base64", sensitive = true}]
-TEST_VARIABLE = ["abc", {command = "echo def"}]
+PASSWORD = ["hunter2", {shell = "echo secret_password | base64", sensitive = true}]
+TEST_VARIABLE = ["abc", {command = ["echo", "def"]}]
 
 [apps.server]
 dev = {SERVICE1 = "dev", SERVICE2 = "also-dev"}

--- a/src/config/cereal.rs
+++ b/src/config/cereal.rs
@@ -6,6 +6,7 @@ use serde::{
     Deserialize, Deserializer,
 };
 
+// Custom deserialization for ValueSource, to support simple string OR map
 impl<'de> Deserialize<'de> for ValueSource {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,5 +1,8 @@
 use crate::{
-    config::{Application, Config, Profile, ValueSource, ValueSourceKind},
+    config::{
+        Application, Config, NativeCommand, Profile, ValueSource,
+        ValueSourceKind,
+    },
     console,
     shell::Shell,
 };
@@ -169,7 +172,12 @@ impl Environment {
     ) -> anyhow::Result<()> {
         let value = match value_source.0.kind {
             ValueSourceKind::Literal { value } => value,
-            ValueSourceKind::Command { command } => shell.execute(&command)?,
+            ValueSourceKind::NativeCommand {
+                command: NativeCommand { program, arguments },
+            } => shell.execute_native(program, &arguments)?,
+            ValueSourceKind::ShellCommand { command } => {
+                shell.execute_shell(&command)?
+            }
         };
         self.0.insert(
             variable,


### PR DESCRIPTION
- Renamed existing `command` type to `shell`
- Added new native command value source under key `command`

The new value source accepts an array of strings, and expects it to be at least length 1. The first element will be the program to execute, subsequent elements will be the arguments.