### PR TITLE
Read from kubernetes pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ SERVICE2=also-prd
 dev also-dev
 ```
 
+See the [Usage Guide](USAGE.md) for more detailed examples.
+
 ## Installation
 
 Currently, env-select can only be installed via `cargo`:

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ struct Args {
     #[clap(short, long)]
     shell: Option<ShellKind>,
 
-    /// Increase output verbosity, for debugging. Supports up to -vv
+    /// Increase output verbosity, for debugging. Supports up to -vvv
     #[clap(short, long, action = clap::ArgAction::Count)]
     verbose: u8,
 }
@@ -75,8 +75,9 @@ fn main() -> ExitCode {
         .format_module_path(false)
         .format_target(false)
         .filter_level(match args.verbose {
-            0 => LevelFilter::Info,
-            1 => LevelFilter::Debug,
+            0 => LevelFilter::Warn,
+            1 => LevelFilter::Info,
+            2 => LevelFilter::Debug,
             _ => LevelFilter::Trace,
         })
         .init();


### PR DESCRIPTION
Added the new `kubernetes` value source type, which makes it easy to execute a command in a kubernetes pod to get a value. Also:

- Bumped the default logging level from `INFO` to `WARN`, and added a third level of verbosity
- Stderr for executed commands is now forwarded to the user
- Added some more log statements

Closes #18 