### PR TITLE
[#25] Add `run` subcommand for one-off env usage

### DIFF
--- a/.env-select.toml
+++ b/.env-select.toml
@@ -12,3 +12,5 @@ prd = {SERVICE1 = "prd", SERVICE2 = "also-prd"}
 [apps.integration-tests.p1]
 PROFILE_VARIABLE_1 = "abc"
 PROFILE_VARIABLE_2 = "def"
+PROFILE_VARIABLE_3 = {type = "command", command = ["echo", "ghi"]}
+PROFILE_VARIABLE_4 = {type = "shell", command = "echo jkl | cat -"}

--- a/USAGE.md
+++ b/USAGE.md
@@ -106,6 +106,39 @@ If you know the name of the profile you want to select, you can also skip the pr
 dev also-dev
 ```
 
+### Run a single command
+
+If you want to run only a single command in the modified environment, rather than modify the entire shell, you can use `es run` instead of `es set`:
+
+```sh
+# Select the profile to use for the `server` application, then run the command
+> es run server -- echo $SERVICE1 $SERVICE2
+❯ === dev ===
+SERVICE1=dev
+SERVICE2=also-dev
+
+  === prd ===
+SERVICE1=prd
+SERVICE2=also-prd
+
+dev also-dev
+# You can also specify the profile name up front
+> es run server dev -- echo $SERVICE1 $SERVICE2
+dev also-dev
+# The surrounding environment is *not* modified
+> echo $SERVICE1 $SERVICE2
+
+```
+
+`--` is required to delineate the arguments handled by `es` from the command being executed. The executed command is called directly, _not_ executed in a shell. To access shell features in the executed command, you can explicitly run in a subshell:
+
+```sh
+> es run server dev -- sh -c 'echo $SERVICE1 | cat -'
+dev
+```
+
+Make sure to use **single** quotes in those case, otherwise `$SERVICE1` will be evaluted by your shell _before_ executing env-select.
+
 ### Dynamic Values
 
 You can define variables whose values are provided dynamically, by specifying a command to execute rather than a static value. This allows you to provide values that can change over time, or secrets that you don't want appearing in the file. For example:

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,45 @@
+use std::{
+    error::Error,
+    fmt::Display,
+    process::{ExitCode, ExitStatus},
+};
+
+/// An error representing a subprocess failure. **This should only be used when
+/// we want to propagate the exit code**. Not all subprocesses warrant this
+/// behavior!
+#[derive(Copy, Clone, Debug)]
+pub struct ExitCodeError(Option<i32>);
+
+impl Display for ExitCodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "process failed with exit code: ")?;
+        match self.0 {
+            Some(code) => write!(f, "{code}"),
+            None => write!(f, "none"),
+        }
+    }
+}
+
+impl Error for ExitCodeError {}
+
+impl From<&ExitStatus> for ExitCodeError {
+    fn from(value: &ExitStatus) -> Self {
+        Self(value.code())
+    }
+}
+
+impl From<ExitCodeError> for ExitCode {
+    fn from(value: ExitCodeError) -> Self {
+        match value.0 {
+            Some(code) => {
+                // ExitStatus uses i32 but ExitCode uses u8, so we have to toss
+                // out the value if it doesn't fit in u8
+                match u8::try_from(code) {
+                    Ok(code) => ExitCode::from(code),
+                    Err(_) => ExitCode::FAILURE,
+                }
+            }
+            None => ExitCode::FAILURE,
+        }
+    }
+}

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -78,7 +78,7 @@ impl Shell {
     /// Print the shell command(s) that will configure the environment to a
     /// particular set of key=value pairs for this shell type. This command
     /// can later be piped to the source command to apply it.
-    pub fn export(&self, environment: &Environment) {
+    pub fn print_export(&self, environment: &Environment) {
         for (variable, value) in environment.iter_unmasked() {
             // Generate a shell command to export the variable
             match self.kind {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,5 +1,6 @@
 use assert_cmd::Command;
 use rstest::fixture;
+use rstest_reuse::{self, *};
 use std::{env, path::PathBuf};
 
 /// Command to run env-select
@@ -7,6 +8,11 @@ use std::{env, path::PathBuf};
 pub fn env_select() -> Command {
     Command::cargo_bin("env-select").unwrap()
 }
+
+/// Fixture to run test with all shells
+#[template]
+#[rstest]
+pub fn all_shells(#[values("bash", "zsh", "fish")] shell_kind: &str) {}
 
 /// Get the path to the given shell
 pub fn shell_path(shell_kind: &str) -> PathBuf {
@@ -18,17 +24,51 @@ pub fn shell_path(shell_kind: &str) -> PathBuf {
     )
 }
 
-/// Command to the given shell. The directory containing env-select will be
-/// added to the PATH.
-pub fn shell(shell_kind: &str) -> Command {
+/// Run a script inside the given shell. This will use `env-select init` to
+/// load the correct shell function, then
+///
+/// `detect_shell` argument controls whether env-select will guess which shell
+/// it's running under (true) or we'll explicitly tell it with -s (false).
+pub fn execute_script(
+    script: &str,
+    shell_kind: &str,
+    detect_shell: bool,
+) -> Command {
+    // Get the function source from `env-select init`
+    let mut es = env_select();
+    if detect_shell {
+        es.env("SHELL", shell_path(shell_kind));
+    } else {
+        es.args(["-s", shell_kind]);
+    }
+    es.arg("init");
+    let assert = es.assert().success();
+
+    // Inject the function source into the script
+    let function_source = String::from_utf8(assert.get_output().stdout.clone())
+        .expect("Function output is not valid UTF-8");
+    let script = format!(
+        "
+        {function_source}
+        {script}
+        "
+    );
+
     // Add the directory containing env-select to the $PATH
     let env_select_path = PathBuf::from(env!("CARGO_BIN_EXE_env-select"));
     let env_select_dir = env_select_path.parent().unwrap();
     let shell = shell_path(shell_kind);
     let mut command = Command::new(&shell);
-    command.env("SHELL", &shell).env(
-        "PATH",
-        format!("{}:{}", env::var("PATH").unwrap(), env_select_dir.display()),
-    );
+    command
+        .env("SHELL", &shell)
+        .env(
+            "PATH",
+            format!(
+                "{}:{}",
+                env::var("PATH").unwrap(),
+                env_select_dir.display()
+            ),
+        )
+        .args(["-c", &script]);
     command
 }

--- a/tests/test_run.rs
+++ b/tests/test_run.rs
@@ -1,0 +1,34 @@
+//! Test the `run` subcommand
+
+mod common;
+
+use common::*;
+use rstest::rstest;
+use rstest_reuse::{self, *};
+
+/// Test that `es run` exports variables only for the single command
+#[apply(all_shells)]
+fn test_subcommand_run(shell_kind: &str) {
+    // We need ||true because printenv fails when given unknown vars
+    let printenv_command = "printenv \
+        TEST_VARIABLE \
+        PROFILE_VARIABLE_1 \
+        PROFILE_VARIABLE_2 \
+        PROFILE_VARIABLE_3 \
+        PROFILE_VARIABLE_4 || true
+    ";
+    execute_script(
+        &format!(
+            "
+            es run TEST_VARIABLE success -- {printenv_command}
+            echo
+            es run integration-tests p1 -- {printenv_command}
+            "
+        ),
+        shell_kind,
+        true,
+    )
+    .assert()
+    .success()
+    .stdout("success\n\nabc\ndef\nghi\njkl\n");
+}

--- a/tests/test_set.rs
+++ b/tests/test_set.rs
@@ -1,44 +1,32 @@
+//! Test the `set` subcommand
+
 mod common;
 
-use assert_cmd::Command;
 use common::*;
 use rstest::rstest;
 use rstest_reuse::{self, *};
 
-#[template]
-#[rstest]
-fn all_shells(#[values("bash", "zsh", "fish")] shell_kind: &str) {}
-
 /// Test all shell integrations with a simple `es set` command
 #[apply(all_shells)]
-fn test_set(
-    mut env_select: Command,
+fn test_subcommand_set(
     shell_kind: &str,
-    #[values(false, true)] infer: bool,
+    #[values(false, true)] detect_shell: bool,
 ) {
-    if infer {
-        env_select.args(["-s", shell_kind]);
-    } else {
-        env_select.env("SHELL", shell_path(shell_kind));
-    }
-    env_select.arg("init");
-    let assert = env_select.assert().success();
-
-    // Pipe the function source to the shell
-    let function_source = String::from_utf8(assert.get_output().stdout.clone())
-        .expect("Invalid function output");
-    // This script should run in all shells
-    let script = format!(
+    execute_script(
         "
-        {function_source}
         es set TEST_VARIABLE success
         es set integration-tests p1
-        echo -n $TEST_VARIABLE $PROFILE_VARIABLE_1 $PROFILE_VARIABLE_2
-        "
-    );
-    shell(shell_kind)
-        .args(["-c", &script])
-        .assert()
-        .success()
-        .stdout("success abc def");
+        echo -n \
+            $TEST_VARIABLE \
+            $PROFILE_VARIABLE_1 \
+            $PROFILE_VARIABLE_2 \
+            $PROFILE_VARIABLE_3 \
+            $PROFILE_VARIABLE_4
+        ",
+        shell_kind,
+        detect_shell,
+    )
+    .assert()
+    .success()
+    .stdout("success abc def ghi jkl");
 }


### PR DESCRIPTION
I also made the variable/application command arg required. Previously it was optional, but not passing it would spit out an error with a suggestion. The suggestion was nice, but I think it made the usage string confusing. In the future we can change it back to optional and offer an additional TUI to select var/application (before the value/profile selection).

Closes #25 