### PR TITLE
Defer shell path loading

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -271,6 +271,18 @@ impl Display for NativeCommand {
     }
 }
 
+// This makes it more ergonomic to call execute_native
+impl<'a, S: Into<String>, I: IntoIterator<Item = &'a str>> From<(S, I)>
+    for NativeCommand
+{
+    fn from((program, arguments): (S, I)) -> Self {
+        Self {
+            program: program.into(),
+            arguments: arguments.into_iter().map(|s| s.to_owned()).collect(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,8 +1,5 @@
 use crate::{
-    config::{
-        Application, Config, NativeCommand, Profile, ValueSource,
-        ValueSourceKind,
-    },
+    config::{Application, Config, Profile, ValueSource, ValueSourceKind},
     console,
     shell::Shell,
 };
@@ -186,9 +183,9 @@ impl Environment {
             // Plain value
             ValueSourceKind::Literal { value } => value,
             // Run a program+args locally
-            ValueSourceKind::NativeCommand {
-                command: NativeCommand { program, arguments },
-            } => Shell::execute_native(program, &arguments)?,
+            ValueSourceKind::NativeCommand { command } => {
+                Shell::execute_native(command)?
+            }
             // Run a program+args in a kubernetes pod/container
             ValueSourceKind::KubernetesCommand {
                 command,

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,7 +208,7 @@ fn run(args: &Args) -> anyhow::Result<()> {
             exporter.print_export_commands(select_key, profile.as_deref())
         }
         Commands::Show => {
-            println!("Shell: {}", shell.path.to_string_lossy());
+            println!("Shell: {}", shell.kind);
             println!();
             println!("{}", toml::to_string(&config)?);
             Ok(())


### PR DESCRIPTION
Defer loading the shell path until it's actually needed. This means anything that doesn't actually call the shell doesn't need the shell to be present on the machine. This will help with running `env-select init` during brew installation.

Also refactored some logic in `execute_native` to take `NativeCommand` instead, which makes it easier to print the command in debug output.