### PR TITLE
Refactor config some more

### DIFF
--- a/.env-select.toml
+++ b/.env-select.toml
@@ -1,11 +1,12 @@
-[applications.server.profiles]
-dev = {SERVICE1 = "dev", SERVICE2 = "also-dev"}
-prd = {SERVICE1 = "prd", SERVICE2 = "also-prd"}
+[applications.server.profiles.dev]
+variables = {SERVICE1 = "dev", SERVICE2 = "also-dev"}
+[applications.server.profiles.prd]
+variables = {SERVICE1 = "prd", SERVICE2 = "also-prd"}
 
 [applications.empty]
 
 # TODO move into tests/ directory
-[applications.integration-tests.profiles.p1]
+[applications.integration-tests.profiles.p1.variables]
 VARIABLE1 = "abc"
 VARIABLE2 = "def"
 VARIABLE3 = {type = "command", command = ["echo", "ghi"]}

--- a/.env-select.toml
+++ b/.env-select.toml
@@ -1,7 +1,3 @@
-[vars]
-PASSWORD = ["hunter2", {type = "shell", command = "echo secret_password | base64", sensitive = true}]
-TEST_VARIABLE = ["abc", {type = "command", command = ["echo", "def"]}]
-
 [apps.server]
 dev = {SERVICE1 = "dev", SERVICE2 = "also-dev"}
 prd = {SERVICE1 = "prd", SERVICE2 = "also-prd"}
@@ -10,7 +6,7 @@ prd = {SERVICE1 = "prd", SERVICE2 = "also-prd"}
 
 # TODO move into tests/ directory
 [apps.integration-tests.p1]
-PROFILE_VARIABLE_1 = "abc"
-PROFILE_VARIABLE_2 = "def"
-PROFILE_VARIABLE_3 = {type = "command", command = ["echo", "ghi"]}
-PROFILE_VARIABLE_4 = {type = "shell", command = "echo jkl | cat -"}
+VARIABLE1 = "abc"
+VARIABLE2 = "def"
+VARIABLE3 = {type = "command", command = ["echo", "ghi"]}
+VARIABLE4 = {type = "shell", command = "echo jkl | cat -"}

--- a/.env-select.toml
+++ b/.env-select.toml
@@ -1,11 +1,11 @@
-[apps.server]
+[applications.server]
 dev = {SERVICE1 = "dev", SERVICE2 = "also-dev"}
 prd = {SERVICE1 = "prd", SERVICE2 = "also-prd"}
 
-[apps.empty]
+[applications.empty]
 
 # TODO move into tests/ directory
-[apps.integration-tests.p1]
+[applications.integration-tests.p1]
 VARIABLE1 = "abc"
 VARIABLE2 = "def"
 VARIABLE3 = {type = "command", command = ["echo", "ghi"]}

--- a/.env-select.toml
+++ b/.env-select.toml
@@ -1,11 +1,11 @@
-[applications.server]
+[applications.server.profiles]
 dev = {SERVICE1 = "dev", SERVICE2 = "also-dev"}
 prd = {SERVICE1 = "prd", SERVICE2 = "also-prd"}
 
 [applications.empty]
 
 # TODO move into tests/ directory
-[applications.integration-tests.p1]
+[applications.integration-tests.profiles.p1]
 VARIABLE1 = "abc"
 VARIABLE2 = "def"
 VARIABLE3 = {type = "command", command = ["echo", "ghi"]}

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Easily switch between predefined values for arbitrary environment variables Feat
 
 ```toml
 # .env-select.toml
-[applications.server]
+[applications.server.profiles]
 dev = {SERVICE1 = "dev", SERVICE2 = "also-dev"}
 prd = {SERVICE1 = "prd", SERVICE2 = "also-prd"}
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Easily switch between predefined values for arbitrary environment variables Feat
 
 ```toml
 # .env-select.toml
-[apps.server]
+[applications.server]
 dev = {SERVICE1 = "dev", SERVICE2 = "also-dev"}
 prd = {SERVICE1 = "prd", SERVICE2 = "also-prd"}
 ```

--- a/README.md
+++ b/README.md
@@ -23,9 +23,11 @@ Easily switch between predefined values for arbitrary environment variables Feat
 
 ```toml
 # .env-select.toml
-[applications.server.profiles]
-dev = {SERVICE1 = "dev", SERVICE2 = "also-dev"}
-prd = {SERVICE1 = "prd", SERVICE2 = "also-prd"}
+[applications.server.profiles.dev]
+variables = {SERVICE1 = "dev", SERVICE2 = "also-dev"}
+
+[applications.server.profiles.prd]
+variables = {SERVICE1 = "prd", SERVICE2 = "also-prd"}
 ```
 
 ```sh

--- a/USAGE.md
+++ b/USAGE.md
@@ -53,11 +53,11 @@ SERVICE2=also-prd
 First, define `.env-select.toml`. This is where you'll specify possible options for each variable. Here's an example:
 
 ```toml
-[applications.server]
+[applications.server.profiles]
 dev = {SERVICE1 = "dev", SERVICE2 = "also-dev"}
 prd = {SERVICE1 = "prd", SERVICE2 = "also-prd"}
 
-[applications.db]
+[applications.db.profiles]
 dev = {DATABASE = "dev", DB_USER = "root",  DB_PASSWORD = "badpw"}
 stg = {DATABASE = "stg", DB_USER = "root", DB_PASSWORD = "goodpw"}
 prd = {DATABASE = "prd", DB_USER = "root", DB_PASSWORD = "greatpw"}
@@ -129,7 +129,7 @@ Make sure to use **single** quotes in those case, otherwise `$SERVICE1` will be 
 You can define variables whose values are provided dynamically, by specifying a command to execute rather than a static value. This allows you to provide values that can change over time, or secrets that you don't want appearing in the file. For example:
 
 ```toml
-[applications.db.dev]
+[applications.db.profiles.dev]
 DATABASE = "dev"
 DB_USER = "root"
 DB_PASSWORD = {type = "command", command = ["cat", "password.txt"], sensitive = true}
@@ -140,7 +140,7 @@ When the `dev` profile is selected for the `db` app, the `DB_PASSWORD` value wil
 By default, the program (the first argument in the list) is executed directly by env-select, and passed the rest of the list as arguments. If you want to execute a command in your shell, you can use the `shell` type instead. This will give access to shell features such as aliases and pipes. For example:
 
 ```toml
-[applications.db.dev]
+[applications.db.profiles.dev]
 DATABASE = "dev"
 DB_USER = "root"
 DB_PASSWORD = {type = "shell", command = "echo password | base64", sensitive = true}
@@ -151,12 +151,12 @@ DB_PASSWORD = {type = "shell", command = "echo password | base64", sensitive = t
 Ever had a secret in a Kubernetes pod that you want to fetch easily? The `kubernetes` value source lets you run any command in a kubernetes pod.
 
 ```toml
-[applications.db.dev]
+[applications.db.profiles.dev]
 DATABASE = "dev"
 DB_USER = "root"
 DB_PASSWORD = {type = "kubernetes", namespace = "development", pod_selector = "app=api", command = ["printenv", "DB_PASSWORD"]}
 
-[applications.db.prd]
+[applications.db.profiles.prd]
 DATABASE = "prd"
 DB_USER = "root"
 DB_PASSWORD = {type = "kubernetes", namespace = "production", pod_selector = "app=api", command = ["printenv", "DB_PASSWORD"]}
@@ -175,7 +175,7 @@ Configuration is defined in [TOML](https://toml.io/en/). The main table in the c
 Let's see this in action:
 
 ```toml
-[applications.server]
+[applications.server.profiles]
 dev = {SERVICE1 = "dev", SERVICE2 = "also-dev"}
 prd = {SERVICE1 = "prd", SERVICE2 = "also-prd"}
 
@@ -185,14 +185,14 @@ prd = {SERVICE1 = "prd", SERVICE2 = "also-prd"}
 # These profiles are big, so we can use full table syntax instead of the
 # inline syntax. This is purely stylistic; you can make your inline
 # tables as big as your heart desires. See https://toml.io/en/v1.0.0#table
-[applications.big.prof1]
+[applications.big.profiles.prof1]
 VAR1 = "yes"
 VAR2 = "yes"
 VAR3 = "no"
 VAR4 = "no"
 VAR5 = "yes"
 
-[applications.big.prof2]
+[applications.big.profiles.prof2]
 VAR1 = "no"
 VAR2 = "no"
 VAR3 = "no"
@@ -205,7 +205,7 @@ VAR5 = "no"
 Profiles within an app can define differing sets of variables, like so:
 
 ```toml
-[applications.db]
+[applications.db.profiles]
 dev = {DATABASE = "dev", DB_USER = "root"}
 stg = {DATABASE = "stg", DB_USER = "root", DB_PASSWORD = "goodpw"}
 prd = {DATABASE = "prd", DB_USER = "root", DB_PASSWORD = "greatpw"}
@@ -219,13 +219,13 @@ On every execution, env-select will scan the current directory for a file called
 
 ```toml
 # ~/code/.env-select.toml
-[applications.server]
+[applications.server.profiles]
 dev = {SERVICE1 = "secret-dev-server", SERVICE2 = "another-secret-dev-server"}
 ```
 
 ```toml
 # ~/.env-select.toml
-[applications.server]
+[applications.server.profiles]
 dev = {SERVICE1 = "dev", SERVICE2 = "also-dev"}
 prd = {SERVICE1 = "prd", SERVICE2 = "also-prd"}
 ```
@@ -234,7 +234,7 @@ then our resulting config, at execution time, will look like:
 
 ```toml
 # Note: this config never exists in the file system, only in memory during program execution
-[applications.server]
+[applications.server.profiles]
 # From ~/code/.env-select.toml (higher precedence)
 dev = {SERVICE1 = "secret-dev-server", SERVICE2 = "another-secret-dev-server"}
 # From ~/.env-select.toml (no value in ~/code/.env-select.toml)
@@ -253,17 +253,17 @@ There are multiple types of value sources. The type used for a value source is d
 # All of these profiles will generate the same exported value for GREETING
 
 # Literal shorthand - most common
-[applications.example.shorthand]
+[applications.example.profiles.shorthand]
 GREETING = "hello"
 
 # Literal expanded form - generally not needed
-[applications.example.literal]
+[applications.example.profiles.literal]
 GREETING = {type = "literal", value = "hello"},
 
-[applications.example.command]
+[applications.example.profiles.command]
 GREETING = {type = "command", command = ["echo", "hello"]}, # Native command
 
-[applications.example.shell]
+[applications.example.profiles.shell]
 GREETING = {type = "shell", command = "echo hello | cat -"}, # Shell command
 ```
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -53,14 +53,18 @@ SERVICE2=also-prd
 First, define `.env-select.toml`. This is where you'll specify possible options for each variable. Here's an example:
 
 ```toml
-[applications.server.profiles]
-dev = {SERVICE1 = "dev", SERVICE2 = "also-dev"}
-prd = {SERVICE1 = "prd", SERVICE2 = "also-prd"}
+[applications.server.profiles.dev]
+variables = {SERVICE1 = "dev", SERVICE2 = "also-dev"}
 
-[applications.db.profiles]
-dev = {DATABASE = "dev", DB_USER = "root",  DB_PASSWORD = "badpw"}
-stg = {DATABASE = "stg", DB_USER = "root", DB_PASSWORD = "goodpw"}
-prd = {DATABASE = "prd", DB_USER = "root", DB_PASSWORD = "greatpw"}
+[applications.server.profiles.prd]
+variables = {SERVICE1 = "prd", SERVICE2 = "also-prd"}
+
+[applications.db.profiles.dev]
+variables = {DATABASE = "dev", DB_USER = "root",  DB_PASSWORD = "badpw"}
+[applications.db.profiles.stg]
+variables = {DATABASE = "stg", DB_USER = "root", DB_PASSWORD = "goodpw"}
+[applications.db.profiles.prd]
+variables = {DATABASE = "prd", DB_USER = "root", DB_PASSWORD = "greatpw"}
 ```
 
 Now, you can easily switch between the defined values with `es`.
@@ -129,7 +133,7 @@ Make sure to use **single** quotes in those case, otherwise `$SERVICE1` will be 
 You can define variables whose values are provided dynamically, by specifying a command to execute rather than a static value. This allows you to provide values that can change over time, or secrets that you don't want appearing in the file. For example:
 
 ```toml
-[applications.db.profiles.dev]
+[applications.db.profiles.dev.variables]
 DATABASE = "dev"
 DB_USER = "root"
 DB_PASSWORD = {type = "command", command = ["cat", "password.txt"], sensitive = true}
@@ -140,7 +144,7 @@ When the `dev` profile is selected for the `db` app, the `DB_PASSWORD` value wil
 By default, the program (the first argument in the list) is executed directly by env-select, and passed the rest of the list as arguments. If you want to execute a command in your shell, you can use the `shell` type instead. This will give access to shell features such as aliases and pipes. For example:
 
 ```toml
-[applications.db.profiles.dev]
+[applications.db.profiles.dev.variables]
 DATABASE = "dev"
 DB_USER = "root"
 DB_PASSWORD = {type = "shell", command = "echo password | base64", sensitive = true}
@@ -151,12 +155,12 @@ DB_PASSWORD = {type = "shell", command = "echo password | base64", sensitive = t
 Ever had a secret in a Kubernetes pod that you want to fetch easily? The `kubernetes` value source lets you run any command in a kubernetes pod.
 
 ```toml
-[applications.db.profiles.dev]
+[applications.db.profiles.dev.variables]
 DATABASE = "dev"
 DB_USER = "root"
 DB_PASSWORD = {type = "kubernetes", namespace = "development", pod_selector = "app=api", command = ["printenv", "DB_PASSWORD"]}
 
-[applications.db.profiles.prd]
+[applications.db.profiles.prd.variables]
 DATABASE = "prd"
 DB_USER = "root"
 DB_PASSWORD = {type = "kubernetes", namespace = "production", pod_selector = "app=api", command = ["printenv", "DB_PASSWORD"]}
@@ -170,14 +174,13 @@ command = ["sh", "-c", "env | grep DB_PASSWORD | sed -E 's/.+=(.+)/\1/'"]
 
 ## Configuration
 
-Configuration is defined in [TOML](https://toml.io/en/). The main table in the config is `applications`. Each sub-table is a profile. Each profile consists of a mapping of `VARIABLE = <value source>`
-
-Let's see this in action:
+Configuration is defined in [TOML](https://toml.io/en/). Let's see this in action:
 
 ```toml
-[applications.server.profiles]
-dev = {SERVICE1 = "dev", SERVICE2 = "also-dev"}
-prd = {SERVICE1 = "prd", SERVICE2 = "also-prd"}
+[applications.server.profiles.variables.dev]
+variables = {SERVICE1 = "dev", SERVICE2 = "also-dev"}
+[applications.server.profiles.variables.prd]
+variables = {SERVICE1 = "prd", SERVICE2 = "also-prd"}
 
 # This application has no profiles, but is still valid to configure
 [applications.empty]
@@ -185,14 +188,14 @@ prd = {SERVICE1 = "prd", SERVICE2 = "also-prd"}
 # These profiles are big, so we can use full table syntax instead of the
 # inline syntax. This is purely stylistic; you can make your inline
 # tables as big as your heart desires. See https://toml.io/en/v1.0.0#table
-[applications.big.profiles.prof1]
+[applications.big.profiles.prof1.variables]
 VAR1 = "yes"
 VAR2 = "yes"
 VAR3 = "no"
 VAR4 = "no"
 VAR5 = "yes"
 
-[applications.big.profiles.prof2]
+[applications.big.profiles.prof2.variables]
 VAR1 = "no"
 VAR2 = "no"
 VAR3 = "no"
@@ -205,10 +208,12 @@ VAR5 = "no"
 Profiles within an app can define differing sets of variables, like so:
 
 ```toml
-[applications.db.profiles]
-dev = {DATABASE = "dev", DB_USER = "root"}
-stg = {DATABASE = "stg", DB_USER = "root", DB_PASSWORD = "goodpw"}
-prd = {DATABASE = "prd", DB_USER = "root", DB_PASSWORD = "greatpw"}
+[applications.db.profiles.dev]
+variables = {DATABASE = "dev", DB_USER = "root"}
+[applications.db.profiles.stg]
+variables = {DATABASE = "stg", DB_USER = "root", DB_PASSWORD = "goodpw"}
+[applications.db.profiles.prd]
+variables = {DATABASE = "prd", DB_USER = "root", DB_PASSWORD = "greatpw"}
 ```
 
 The `dev` profile excludes the `DB_PASSWORD` variable. Beware though, whenever switch to the dev profile, it will simply not output a value for `DB_PASSWORD`. That means if you're switch from another profile, `DB_PASSWORD` will retain its old value! For this reason, it's generally best to define the same set of values for every profile in an app, and just use empty values as appropriate.
@@ -219,26 +224,28 @@ On every execution, env-select will scan the current directory for a file called
 
 ```toml
 # ~/code/.env-select.toml
-[applications.server.profiles]
-dev = {SERVICE1 = "secret-dev-server", SERVICE2 = "another-secret-dev-server"}
+[applications.server.profiles.dev]
+variables = {SERVICE1 = "secret-dev-server", SERVICE2 = "another-secret-dev-server"}
 ```
 
 ```toml
 # ~/.env-select.toml
-[applications.server.profiles]
-dev = {SERVICE1 = "dev", SERVICE2 = "also-dev"}
-prd = {SERVICE1 = "prd", SERVICE2 = "also-prd"}
+[applications.server.profiles.dev]
+variables = {SERVICE1 = "dev", SERVICE2 = "also-dev"}
+[applications.server.profiles.prd]
+variables = {SERVICE1 = "prd", SERVICE2 = "also-prd"}
 ```
 
 then our resulting config, at execution time, will look like:
 
 ```toml
 # Note: this config never exists in the file system, only in memory during program execution
-[applications.server.profiles]
 # From ~/code/.env-select.toml (higher precedence)
-dev = {SERVICE1 = "secret-dev-server", SERVICE2 = "another-secret-dev-server"}
+[applications.server.profiles.dev]
+variables = {SERVICE1 = "secret-dev-server", SERVICE2 = "another-secret-dev-server"}
 # From ~/.env-select.toml (no value in ~/code/.env-select.toml)
-prd = {SERVICE1 = "prd", SERVICE2 = "also-prd"}
+[applications.server.profiles.prd]
+variables = {SERVICE1 = "prd", SERVICE2 = "also-prd"}
 ```
 
 To see where env-select is loading configs from, and how they are being merged together, run the command with the `--verbose` (or `-v`) flag.
@@ -253,17 +260,17 @@ There are multiple types of value sources. The type used for a value source is d
 # All of these profiles will generate the same exported value for GREETING
 
 # Literal shorthand - most common
-[applications.example.profiles.shorthand]
+[applications.example.profiles.shorthand.variables]
 GREETING = "hello"
 
 # Literal expanded form - generally not needed
-[applications.example.profiles.literal]
+[applications.example.profiles.literal.variables]
 GREETING = {type = "literal", value = "hello"},
 
-[applications.example.profiles.command]
+[applications.example.profiles.command.variables]
 GREETING = {type = "command", command = ["echo", "hello"]}, # Native command
 
-[applications.example.profiles.shell]
+[applications.example.profiles.shell.variables]
 GREETING = {type = "shell", command = "echo hello | cat -"}, # Shell command
 ```
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -53,11 +53,11 @@ SERVICE2=also-prd
 First, define `.env-select.toml`. This is where you'll specify possible options for each variable. Here's an example:
 
 ```toml
-[apps.server]
+[applications.server]
 dev = {SERVICE1 = "dev", SERVICE2 = "also-dev"}
 prd = {SERVICE1 = "prd", SERVICE2 = "also-prd"}
 
-[apps.db]
+[applications.db]
 dev = {DATABASE = "dev", DB_USER = "root",  DB_PASSWORD = "badpw"}
 stg = {DATABASE = "stg", DB_USER = "root", DB_PASSWORD = "goodpw"}
 prd = {DATABASE = "prd", DB_USER = "root", DB_PASSWORD = "greatpw"}
@@ -129,7 +129,7 @@ Make sure to use **single** quotes in those case, otherwise `$SERVICE1` will be 
 You can define variables whose values are provided dynamically, by specifying a command to execute rather than a static value. This allows you to provide values that can change over time, or secrets that you don't want appearing in the file. For example:
 
 ```toml
-[apps.db.dev]
+[applications.db.dev]
 DATABASE = "dev"
 DB_USER = "root"
 DB_PASSWORD = {type = "command", command = ["cat", "password.txt"], sensitive = true}
@@ -140,7 +140,7 @@ When the `dev` profile is selected for the `db` app, the `DB_PASSWORD` value wil
 By default, the program (the first argument in the list) is executed directly by env-select, and passed the rest of the list as arguments. If you want to execute a command in your shell, you can use the `shell` type instead. This will give access to shell features such as aliases and pipes. For example:
 
 ```toml
-[apps.db.dev]
+[applications.db.dev]
 DATABASE = "dev"
 DB_USER = "root"
 DB_PASSWORD = {type = "shell", command = "echo password | base64", sensitive = true}
@@ -151,12 +151,12 @@ DB_PASSWORD = {type = "shell", command = "echo password | base64", sensitive = t
 Ever had a secret in a Kubernetes pod that you want to fetch easily? The `kubernetes` value source lets you run any command in a kubernetes pod.
 
 ```toml
-[apps.db.dev]
+[applications.db.dev]
 DATABASE = "dev"
 DB_USER = "root"
 DB_PASSWORD = {type = "kubernetes", namespace = "development", pod_selector = "app=api", command = ["printenv", "DB_PASSWORD"]}
 
-[apps.db.prd]
+[applications.db.prd]
 DATABASE = "prd"
 DB_USER = "root"
 DB_PASSWORD = {type = "kubernetes", namespace = "production", pod_selector = "app=api", command = ["printenv", "DB_PASSWORD"]}
@@ -170,29 +170,29 @@ command = ["sh", "-c", "env | grep DB_PASSWORD | sed -E 's/.+=(.+)/\1/'"]
 
 ## Configuration
 
-Configuration is defined in [TOML](https://toml.io/en/). The main table in the config is `apps`. Each sub-table is a profile. Each profile consists of a mapping of `VARIABLE = <value source>`
+Configuration is defined in [TOML](https://toml.io/en/). The main table in the config is `applications`. Each sub-table is a profile. Each profile consists of a mapping of `VARIABLE = <value source>`
 
 Let's see this in action:
 
 ```toml
-[apps.server]
+[applications.server]
 dev = {SERVICE1 = "dev", SERVICE2 = "also-dev"}
 prd = {SERVICE1 = "prd", SERVICE2 = "also-prd"}
 
 # This application has no profiles, but is still valid to configure
-[apps.empty]
+[applications.empty]
 
 # These profiles are big, so we can use full table syntax instead of the
 # inline syntax. This is purely stylistic; you can make your inline
 # tables as big as your heart desires. See https://toml.io/en/v1.0.0#table
-[apps.big.prof1]
+[applications.big.prof1]
 VAR1 = "yes"
 VAR2 = "yes"
 VAR3 = "no"
 VAR4 = "no"
 VAR5 = "yes"
 
-[apps.big.prof2]
+[applications.big.prof2]
 VAR1 = "no"
 VAR2 = "no"
 VAR3 = "no"
@@ -205,7 +205,7 @@ VAR5 = "no"
 Profiles within an app can define differing sets of variables, like so:
 
 ```toml
-[apps.db]
+[applications.db]
 dev = {DATABASE = "dev", DB_USER = "root"}
 stg = {DATABASE = "stg", DB_USER = "root", DB_PASSWORD = "goodpw"}
 prd = {DATABASE = "prd", DB_USER = "root", DB_PASSWORD = "greatpw"}
@@ -219,13 +219,13 @@ On every execution, env-select will scan the current directory for a file called
 
 ```toml
 # ~/code/.env-select.toml
-[apps.server]
+[applications.server]
 dev = {SERVICE1 = "secret-dev-server", SERVICE2 = "another-secret-dev-server"}
 ```
 
 ```toml
 # ~/.env-select.toml
-[apps.server]
+[applications.server]
 dev = {SERVICE1 = "dev", SERVICE2 = "also-dev"}
 prd = {SERVICE1 = "prd", SERVICE2 = "also-prd"}
 ```
@@ -234,7 +234,7 @@ then our resulting config, at execution time, will look like:
 
 ```toml
 # Note: this config never exists in the file system, only in memory during program execution
-[apps.server]
+[applications.server]
 # From ~/code/.env-select.toml (higher precedence)
 dev = {SERVICE1 = "secret-dev-server", SERVICE2 = "another-secret-dev-server"}
 # From ~/.env-select.toml (no value in ~/code/.env-select.toml)
@@ -253,17 +253,17 @@ There are multiple types of value sources. The type used for a value source is d
 # All of these profiles will generate the same exported value for GREETING
 
 # Literal shorthand - most common
-[apps.example.shorthand]
+[applications.example.shorthand]
 GREETING = "hello"
 
 # Literal expanded form - generally not needed
-[apps.example.literal]
+[applications.example.literal]
 GREETING = {type = "literal", value = "hello"},
 
-[apps.example.command]
+[applications.example.command]
 GREETING = {type = "command", command = ["echo", "hello"]}, # Native command
 
-[apps.example.shell]
+[applications.example.shell]
 GREETING = {type = "shell", command = "echo hello | cat -"}, # Shell command
 ```
 

--- a/shells/es.bash
+++ b/shells/es.bash
@@ -1,8 +1,8 @@
 es () {
-    env-select test $@ > /dev/null 2>&1
+    ENV_SELECT_BINARY test $@ > /dev/null 2>&1
     if [ $? -eq 0 ]; then
         tmp_file=$(mktemp)
-        env-select $@ > $tmp_file
+        ENV_SELECT_BINARY $@ > $tmp_file
         return_code=$?
         if [ $return_code -eq 0 ]; then
             source $tmp_file
@@ -10,7 +10,7 @@ es () {
         rm $tmp_file
         return $return_code
     else
-        env-select $@
+        ENV_SELECT_BINARY $@
         return $?
     fi
 }

--- a/shells/es.fish
+++ b/shells/es.fish
@@ -2,17 +2,17 @@ function es --description "Fish wrapper for env-select"
     # Test if argv is a `set` command. If so, we'll capture the output. If not,
     # run the command as normal. We silence output here because we're going to
     # execute the command regardless, so if it's an error it'll show up later.
-    env-select test $argv &> /dev/null
+    ENV_SELECT_BINARY test $argv &> /dev/null
 
     if test $status -eq 0
-        set output (env-select $argv)
+        set output (ENV_SELECT_BINARY $argv)
         set return_code $status
         if test $status -eq 0
             string join \n $output | source
         end
         return $return_code
     else
-        env-select $argv
+        ENV_SELECT_BINARY $argv
         return $status
     end
 end

--- a/shells/es.zsh
+++ b/shells/es.zsh
@@ -1,14 +1,14 @@
 es () {
-    env-select test $argv > /dev/null 2>&1
+    ENV_SELECT_BINARY test $argv > /dev/null 2>&1
     if [ $? -eq 0 ]; then
-        output=$(env-select $argv)
+        output=$(ENV_SELECT_BINARY $argv)
         return_code=$?
         if [ $return_code -eq 0 ]; then
             source <(echo $output)
         fi
         return $return_code
     else
-        env-select $argv
+        ENV_SELECT_BINARY $argv
         return $?
     fi
 }

--- a/src/config/merge.rs
+++ b/src/config/merge.rs
@@ -12,7 +12,6 @@ pub trait Merge {
 
 impl Merge for Config {
     fn merge(&mut self, other: Self) {
-        self.variables.merge(other.variables);
         self.applications.merge(other.applications);
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -25,7 +25,7 @@ pub struct Config {
     /// application typically has one or more variables that control it, and
     /// each variable may multiple values to select between. Each value set
     /// is known as a "profile".
-    #[serde(default, rename = "apps")]
+    #[serde(default)]
     pub applications: IndexMap<String, Application>,
 }
 
@@ -278,15 +278,15 @@ mod tests {
     };
 
     const CONFIG: &str = r#"
-[apps.server]
+[applications.server]
 dev = {SERVICE1 = "dev", SERVICE2 = "also-dev"}
 prd = {SERVICE1 = "prd", SERVICE2 = "also-prd"}
-[apps.server.secret]
+[applications.server.secret]
 SERVICE1 = {type = "literal", value = "secret", sensitive = true}
 SERVICE2 = {type = "command", command = ["echo", "also-secret"], sensitive = true}
 SERVICE3 = {type = "shell", command = "echo secret_password | base64", sensitive = true}
 
-[apps.empty]
+[applications.empty]
     "#;
 
     /// Helper for building an IndexMap

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -42,7 +42,7 @@ pub struct Application {
 /// a singular value.
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Eq, PartialEq)]
 pub struct Profile {
-    #[serde(flatten)]
+    #[serde(default)]
     pub variables: IndexMap<String, ValueSource>,
 }
 
@@ -278,10 +278,12 @@ mod tests {
     };
 
     const CONFIG: &str = r#"
-[applications.server.profiles]
-dev = {SERVICE1 = "dev", SERVICE2 = "also-dev"}
-prd = {SERVICE1 = "prd", SERVICE2 = "also-prd"}
-[applications.server.profiles.secret]
+[applications.server.profiles.dev]
+variables = {SERVICE1 = "dev", SERVICE2 = "also-dev"}
+[applications.server.profiles.prd]
+variables = {SERVICE1 = "prd", SERVICE2 = "also-prd"}
+
+[applications.server.profiles.secret.variables]
 SERVICE1 = {type = "literal", value = "secret", sensitive = true}
 SERVICE2 = {type = "command", command = ["echo", "also-secret"], sensitive = true}
 SERVICE3 = {type = "shell", command = "echo secret_password | base64", sensitive = true}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -34,7 +34,7 @@ pub struct Config {
 /// Different colors of the same car, so to speak.
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Eq, PartialEq)]
 pub struct Application {
-    #[serde(flatten)]
+    #[serde(default)]
     pub profiles: IndexMap<String, Profile>,
 }
 
@@ -278,10 +278,10 @@ mod tests {
     };
 
     const CONFIG: &str = r#"
-[applications.server]
+[applications.server.profiles]
 dev = {SERVICE1 = "dev", SERVICE2 = "also-dev"}
 prd = {SERVICE1 = "prd", SERVICE2 = "also-prd"}
-[applications.server.secret]
+[applications.server.profiles.secret]
 SERVICE1 = {type = "literal", value = "secret", sensitive = true}
 SERVICE2 = {type = "command", command = ["echo", "also-secret"], sensitive = true}
 SERVICE3 = {type = "shell", command = "echo secret_password | base64", sensitive = true}

--- a/src/console.rs
+++ b/src/console.rs
@@ -1,36 +1,11 @@
-use crate::config::{Application, Profile, ValueSource};
+use crate::config::{Application, Profile};
 use anyhow::bail;
 use atty::Stream;
 use dialoguer::{theme::ColorfulTheme, Select};
-use indexmap::IndexSet;
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
 const REPOSITORY: &str = env!("CARGO_PKG_REPOSITORY");
 const VERSION: &str = env!("CARGO_PKG_VERSION");
-
-/// Show a prompt that allows the user to select a value for a variable, from
-/// a given list. The user can also select a "Custom" option to enter their own
-/// value. Returns `Ok(None)` iff the user quits out of the prompt.
-pub fn prompt_variable<'a>(
-    variable: &str,
-    options: &'a IndexSet<ValueSource>,
-) -> anyhow::Result<&'a ValueSource> {
-    let theme = ColorfulTheme::default();
-    // Show a prompt to ask the user which value to use
-    let chosen_index = Select::with_theme(&theme)
-        .items(
-            options
-                .iter()
-                .map(|value| format!("{variable}={value}"))
-                .collect::<Vec<_>>()
-                .as_slice(),
-        )
-        .default(0)
-        .interact()?;
-
-    // This index is safe because it came from the value array above
-    Ok(&options[chosen_index])
-}
 
 /// Show a prompt that allows the user to select a profile for an application,
 /// from a given list.

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,18 +78,16 @@ enum Commands {
     Show,
 }
 
-/// Arguments required for any subcommand that allows variable/profile
+/// Arguments required for any subcommand that allows applcation/profile
 /// selection.
 #[derive(Clone, Debug, clap::Args)]
 struct SelectionArgs {
-    /// The name of the variable or application to select a value for
-    #[arg(name = "VARIABLE|APPLICATION")]
-    // TODO make this optional and allow selecting variable/application in TUI
-    select_key: String,
+    /// The name of the application to select a profile for
+    // TODO make this optional and allow selecting application interactively
+    application: String,
 
     /// Profile to select. If omitted, an interactive prompt will be shown to
-    /// select between possible options. For single variables, this will be
-    /// used as the exported value.
+    /// select between possible options.
     profile: Option<String>,
 }
 
@@ -170,7 +168,7 @@ fn run(args: &Args) -> anyhow::Result<()> {
         Commands::Run {
             selection_args:
                 SelectionArgs {
-                    select_key,
+                    application: select_key,
                     profile,
                 },
             command,
@@ -200,7 +198,7 @@ fn run(args: &Args) -> anyhow::Result<()> {
         Commands::Set {
             selection_args:
                 SelectionArgs {
-                    select_key,
+                    application: select_key,
                     profile,
                 },
         } => {

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -10,6 +10,7 @@ use std::{
     process::{Command, Stdio},
 };
 
+const BINARY_REPLACEMENT_KEY: &str = "ENV_SELECT_BINARY";
 const BASH_WRAPPER: &str = include_str!("../shells/es.bash");
 const ZSH_WRAPPER: &str = include_str!("../shells/es.zsh");
 const FISH_WRAPPER: &str = include_str!("../shells/es.fish");
@@ -62,11 +63,18 @@ impl Shell {
     /// Print a valid shell script that will initialize the `es` wrapper as
     /// well as whatever other initialization is needed.
     pub fn print_init_script(&self) -> anyhow::Result<()> {
-        let wrapper_src = match self.kind {
+        let wrapper_template = match self.kind {
             ShellKind::Bash => BASH_WRAPPER,
             ShellKind::Zsh => ZSH_WRAPPER,
             ShellKind::Fish => FISH_WRAPPER,
         };
+
+        // Inject the path of the current binary into the script. This prevents
+        // any need to modify PATH
+        let wrapper_src = wrapper_template.replace(
+            BINARY_REPLACEMENT_KEY,
+            &env::current_exe()?.display().to_string(),
+        );
 
         println!("{wrapper_src}");
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,7 +1,7 @@
 use assert_cmd::Command;
 use rstest::fixture;
 use rstest_reuse::{self, *};
-use std::{env, path::PathBuf};
+use std::path::PathBuf;
 
 /// Command to run env-select
 #[fixture]
@@ -54,21 +54,8 @@ pub fn execute_script(
         "
     );
 
-    // Add the directory containing env-select to the $PATH
-    let env_select_path = PathBuf::from(env!("CARGO_BIN_EXE_env-select"));
-    let env_select_dir = env_select_path.parent().unwrap();
     let shell = shell_path(shell_kind);
     let mut command = Command::new(&shell);
-    command
-        .env("SHELL", &shell)
-        .env(
-            "PATH",
-            format!(
-                "{}:{}",
-                env::var("PATH").unwrap(),
-                env_select_dir.display()
-            ),
-        )
-        .args(["-c", &script]);
+    command.env("SHELL", &shell).args(["-c", &script]);
     command
 }

--- a/tests/test_run.rs
+++ b/tests/test_run.rs
@@ -10,19 +10,12 @@ use rstest_reuse::{self, *};
 #[apply(all_shells)]
 fn test_subcommand_run(shell_kind: &str) {
     // We need ||true because printenv fails when given unknown vars
-    let printenv_command = "printenv \
-        TEST_VARIABLE \
-        PROFILE_VARIABLE_1 \
-        PROFILE_VARIABLE_2 \
-        PROFILE_VARIABLE_3 \
-        PROFILE_VARIABLE_4 || true
-    ";
+    let printenv_command = "printenv VARIABLE1 VARIABLE2 VARIABLE3 VARIABLE4";
     execute_script(
         &format!(
             "
-            es run TEST_VARIABLE success -- {printenv_command}
-            echo
             es run integration-tests p1 -- {printenv_command}
+            echo Empty: $VARIABLE1
             "
         ),
         shell_kind,
@@ -30,5 +23,5 @@ fn test_subcommand_run(shell_kind: &str) {
     )
     .assert()
     .success()
-    .stdout("success\n\nabc\ndef\nghi\njkl\n");
+    .stdout("abc\ndef\nghi\njkl\nEmpty:\n");
 }

--- a/tests/test_set.rs
+++ b/tests/test_set.rs
@@ -14,19 +14,17 @@ fn test_subcommand_set(
 ) {
     execute_script(
         "
-        es set TEST_VARIABLE success
         es set integration-tests p1
         echo -n \
-            $TEST_VARIABLE \
-            $PROFILE_VARIABLE_1 \
-            $PROFILE_VARIABLE_2 \
-            $PROFILE_VARIABLE_3 \
-            $PROFILE_VARIABLE_4
+            $VARIABLE1 \
+            $VARIABLE2 \
+            $VARIABLE3 \
+            $VARIABLE4
         ",
         shell_kind,
         detect_shell,
     )
     .assert()
     .success()
-    .stdout("success abc def ghi jkl");
+    .stdout("abc def ghi jkl");
 }


### PR DESCRIPTION
- Delete concept of single variables
  - You now have to create an application with single-variable profiles to achieve the same effect
  - This never felt very useful to me, and was an additional concept to learn that didn't provide any benefit beyond being slightly simpler to write
- Rename `apps` to `applications`
  - This abbreviation is pretty obvious, but I don't want anyone to ever wonder if a key is an abbreviation for the full one when trying to guess
- Inject full binary path into `es` functions
  - Eliminates need for `env-select` to be on `PATH` (unless you're using `env-select init` in your shell profile)
  - This will technically change the behavior for a setup with multiple versions of `env-select` installed (e.g. brew AND cargo). It should be an _improvement_ though, because it makes sure the definition of `es` points to the version of `env-select` that actually generated it
- Unflatten `profiles` and `variables` keys

Here's an example of how the config has changed:

```toml
# Old
[apps.server]
 dev = {SERVICE1 = "dev", SERVICE2 = "also-dev"}
 prd = {SERVICE1 = "prd", SERVICE2 = "also-prd"}

# New
[applications.server.profiles.dev]
variables = {SERVICE1 = "dev", SERVICE2 = "also-dev"}

[applications.server.profiles.prd]
variables = {SERVICE1 = "prd", SERVICE2 = "also-prd"}
```

You _could_ still use inline tables for profiles now, but it'd be pretty ugly. This change makes the config more verbose, but it opens the door for more features, such as profile inheritance (which will use `applications.*.profiles.*.extends`). I don't see any immediate need for any sibling fields to `profiles`, but that might come in down the line and I'd like to head off any potential breaking changes. Bytes are cheap anyway.