### PR TITLE
Add ability to load multiple values from a single source

### DIFF
--- a/.env-select.toml
+++ b/.env-select.toml
@@ -6,10 +6,3 @@ variables = {SERVICE1 = "dev", SERVICE2 = "also-dev"}
 [applications.server.profiles.prd]
 extends = ["base"]
 variables = {SERVICE1 = "prd", SERVICE2 = "also-prd"}
-
-# TODO move into tests/ directory
-[applications.integration-tests.profiles.p1.variables]
-VARIABLE1 = "abc"
-VARIABLE2 = "def"
-VARIABLE3 = {type = "command", command = ["echo", "ghi"]}
-VARIABLE4 = {type = "shell", command = "echo jkl | cat -"}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,6 +136,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,7 +193,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -214,6 +223,25 @@ dependencies = [
  "terminal_size",
  "unicode-width",
  "winapi",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -248,10 +276,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "dotenv-parser"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d4e7e3d829e699806e8f1cb1906e671114c2b955a9c65559756b5f93258e8f0"
+dependencies = [
+ "pest",
+ "pest_derive",
+]
 
 [[package]]
 name = "either"
@@ -275,6 +323,7 @@ dependencies = [
  "clap",
  "ctrlc",
  "dialoguer",
+ "dotenv-parser",
  "env_logger",
  "indexmap",
  "log",
@@ -323,6 +372,16 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -476,6 +535,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
+name = "pest"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f73935e4d55e2abf7f130186537b19e7a4abc886a0252380b59248af473a3fc9"
+dependencies = [
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef623c9bbfa0eedf5a0efba11a5ee83209c326653ca31ff019bec3a95bfff2b"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3e8cba4ec22bada7fc55ffe51e2deb6a0e0db2d0b7ab0b103acc80d2510c190"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.25",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01f71cb40bd8bb94232df14b946909e14660e33fc05db3e50ae2a82d7ea0ca0"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,7 +631,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
  "version_check",
 ]
 
@@ -617,7 +720,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 1.0.102",
  "unicode-ident",
 ]
 
@@ -630,7 +733,7 @@ dependencies = [
  "quote",
  "rand",
  "rustc_version",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -684,7 +787,7 @@ checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -706,6 +809,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -716,6 +830,17 @@ name = "syn"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -746,6 +871,26 @@ name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
+name = "thiserror"
+version = "1.0.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.25",
+]
 
 [[package]]
 name = "toml"
@@ -781,6 +926,18 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ atty = "0.2.14"
 clap = {version = "4.0.17", features = ["derive"]}
 ctrlc = "3.2.3"
 dialoguer = {version = "0.10.2", default-features = false}
+dotenv-parser = {version = "0.1.3", default-features = false}
 env_logger = {version = "0.9.1", default-features = false, features = ["atty", "termcolor"]}
 indexmap = {version = "2.0.0", features = ["serde"]}
 log = "0.4.17"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -90,6 +90,13 @@ pub struct ValueSource(pub ValueSourceInner);
 pub struct ValueSourceInner {
     #[serde(flatten)]
     pub kind: ValueSourceKind,
+
+    /// Source provides a mapping of line-delimited VARIABLE=value settings,
+    /// instead of a single vlaue
+    #[serde(default)]
+    pub multiple: bool,
+
+    /// Value(s) should be masked in display output
     #[serde(default)]
     pub sensitive: bool,
 }
@@ -301,6 +308,7 @@ impl ValueSource {
             kind: ValueSourceKind::Literal {
                 value: value.to_owned(),
             },
+            multiple: false,
             sensitive: false,
         })
     }

--- a/tests/.env-select.toml
+++ b/tests/.env-select.toml
@@ -1,0 +1,5 @@
+[applications.integration-tests.profiles.p1.variables]
+VARIABLE1 = "abc"
+VARIABLE2 = "def"
+VARIABLE3 = {type = "command", command = ["echo", "ghi"]}
+VARIABLE4 = {type = "shell", command = "echo jkl | cat -"}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,12 +1,14 @@
 use assert_cmd::Command;
 use rstest::fixture;
 use rstest_reuse::{self, *};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Command to run env-select
 #[fixture]
 pub fn env_select() -> Command {
-    Command::cargo_bin("env-select").unwrap()
+    let mut command = Command::cargo_bin("env-select").unwrap();
+    command.current_dir(tests_dir());
+    command
 }
 
 /// Fixture to run test with all shells
@@ -56,6 +58,14 @@ pub fn execute_script(
 
     let shell = shell_path(shell_kind);
     let mut command = Command::new(&shell);
-    command.env("SHELL", &shell).args(["-c", &script]);
     command
+        // Run from the tests/ directory, so we can use a dedicated config
+        .current_dir(tests_dir())
+        .env("SHELL", &shell)
+        .args(["-c", &script]);
+    command
+}
+
+fn tests_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/")
 }


### PR DESCRIPTION
- Add `multiple` flag to all value source kinds
- Refactor config tests a bit to make it easier to build `ValueSource`s
- Move `.env-select.toml` for integration tests into `tests/` directory

Closes #26 