### PR TITLE
Support non-string primitives for literal values

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -323,10 +323,10 @@ impl TryFrom<Vec<String>> for NativeCommand {
 impl ValueSource {
     /// Build a [ValueSource] from a simple string value. All extra fields
     /// are populated with defaults.
-    pub fn from_literal(value: &str) -> Self {
+    pub fn from_literal(value: impl ToString) -> Self {
         Self(ValueSourceInner {
             kind: ValueSourceKind::Literal {
-                value: value.to_owned(),
+                value: value.to_string(),
             },
             multiple: false,
             sensitive: false,

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -317,6 +317,17 @@ fn test_parse_value_source() {
 fn test_parse_literal() {
     // Flat syntax
     assert_de_tokens(&literal("abc"), &[Token::Str("abc")]);
+    assert_de_tokens(&literal("true"), &[Token::Bool(true)]);
+    assert_de_tokens(&literal("-16"), &[Token::I8(-16)]);
+    assert_de_tokens(&literal("-16"), &[Token::I16(-16)]);
+    assert_de_tokens(&literal("-16"), &[Token::I32(-16)]);
+    assert_de_tokens(&literal("-16"), &[Token::I64(-16)]);
+    assert_de_tokens(&literal("16"), &[Token::U8(16)]);
+    assert_de_tokens(&literal("16"), &[Token::U16(16)]);
+    assert_de_tokens(&literal("16"), &[Token::U32(16)]);
+    assert_de_tokens(&literal("16"), &[Token::U64(16)]);
+    assert_de_tokens(&literal("420.69000244140625"), &[Token::F32(420.69)]);
+    assert_de_tokens(&literal("420.69"), &[Token::F64(420.69)]);
 
     // Map syntax
     assert_tokens(
@@ -332,17 +343,6 @@ fn test_parse_literal() {
             Token::Str("abc"),
             Token::StructEnd,
         ],
-    );
-
-    // Can't parse non-strings
-    // https://github.com/LucasPickering/env-select/issues/16
-    assert_de_tokens_error::<ValueSource>(
-        &[Token::I32(16)],
-        "invalid type: integer `16`, expected string or map",
-    );
-    assert_de_tokens_error::<ValueSource>(
-        &[Token::Bool(true)],
-        "invalid type: boolean `true`, expected string or map",
     );
 }
 


### PR DESCRIPTION
Add support for parsing booleans, integers, and floats as literal values. They'll simply be stringified during parsing, because environment variables can only be assigned to strings anyway.

Closes #16 