### PR TITLE
Expand `show` subcommand

### DIFF
--- a/src/config/inherit.rs
+++ b/src/config/inherit.rs
@@ -1,6 +1,6 @@
 //! Utilitied related to profile inheritance resolution
 
-use crate::config::{Config, DisplayKeys, Profile, ProfileReference};
+use crate::config::{Config, MapExt, Profile, ProfileReference};
 use anyhow::{anyhow, bail};
 use indexmap::{IndexMap, IndexSet};
 use log::trace;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -385,15 +385,20 @@ impl<'a, S: Into<String>, I: IntoIterator<Item = &'a str>> From<(S, I)>
 /// Itty bitty little helper trait for printing the keys of a map in a
 /// user-friendly format. Useful for showing application and profile options.
 pub trait DisplayKeys {
-    /// Print the keys of this map
-    fn display_keys(&self) -> String;
+    /// Print the keys of this map, comma-delimited
+    fn display_keys(&self) -> String {
+        self.display_keys_delimited(", ")
+    }
+
+    /// Print the keys of this map with the given separator
+    fn display_keys_delimited(&self, separator: &str) -> String;
 }
 
 impl<K: Display + Eq + Hash + PartialEq, V> DisplayKeys for IndexMap<K, V> {
-    fn display_keys(&self) -> String {
+    fn display_keys_delimited(&self, separator: &str) -> String {
         self.keys()
             .map(|key| key.to_string())
             .collect::<Vec<_>>()
-            .join(", ")
+            .join(separator)
     }
 }

--- a/src/console.rs
+++ b/src/console.rs
@@ -1,5 +1,5 @@
-use crate::config::{Application, DisplayKeys, Name, Profile};
-use anyhow::{anyhow, bail};
+use crate::config::{Application, MapExt, Name, Profile};
+use anyhow::bail;
 use atty::Stream;
 use dialoguer::{theme::ColorfulTheme, Select};
 use indexmap::IndexMap;
@@ -15,14 +15,7 @@ pub fn prompt_options<'a, T: Prompt>(
     default_name: Option<&'a Name>,
 ) -> anyhow::Result<&'a T> {
     match default_name {
-        Some(default_name) => options.get(default_name).ok_or_else(|| {
-            anyhow!(
-                "No {} with the name {}, options are: {}",
-                T::SELF_NAME,
-                default_name,
-                options.display_keys()
-            )
-        }),
+        Some(default_name) => options.try_get(default_name),
 
         // Show a prompt to ask the user which profile to use
         None => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,9 +75,8 @@ enum Commands {
         selection: Selection,
     },
 
-    /// Show current configuration, with all available variables and
-    /// applications
-    Show,
+    /// Print configured values. Useful for debugging and completions
+    Show(ShowArgs),
 }
 
 /// Arguments required for any subcommand that allows applcation/profile
@@ -91,6 +90,20 @@ struct Selection {
     /// Profile to select. If omitted, an interactive prompt will be shown to
     /// select between possible options.
     profile: Option<Name>,
+}
+
+#[derive(Clone, Debug, clap::Args)]
+struct ShowArgs {
+    #[command(subcommand)]
+    command: ShowSubcommand,
+}
+
+#[derive(Clone, Debug, Subcommand)]
+enum ShowSubcommand {
+    /// Print full resolved configuration, in TOML format
+    Config,
+    /// Print the name or path to the shell in use
+    Shell,
 }
 
 fn main() -> ExitCode {
@@ -209,8 +222,13 @@ impl Executor {
                     },
             } => self
                 .print_export_commands(application.as_ref(), profile.as_ref()),
-            Commands::Show => {
-                println!("{}", toml::to_string(&self.config)?);
+            Commands::Show(ShowArgs { command }) => {
+                match command {
+                    ShowSubcommand::Config => {
+                        println!("{}", toml::to_string(&self.config)?)
+                    }
+                    ShowSubcommand::Shell => println!("{}", self.shell),
+                }
                 Ok(())
             }
         }

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -209,6 +209,15 @@ impl Shell {
     }
 }
 
+impl Display for Shell {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match &self.path {
+            Some(path) => write!(f, "{} (from $SHELL)", path),
+            None => write!(f, "{} (assumed to be in $PATH)", self.kind),
+        }
+    }
+}
+
 impl Display for ShellKind {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,4 +1,4 @@
-use crate::{config::NativeCommand, console, export::Environment};
+use crate::{config::NativeCommand, console, environment::Environment};
 use anyhow::{anyhow, bail, Context};
 use clap::ValueEnum;
 use log::{debug, info};


### PR DESCRIPTION
Expand the `show` subcommand to have two sub-subcommands:

- `es show config` - Print the whole config as TOML
- `es show shell` - Print the path/name of the shell in use

In the future this can also be used to spit out information for shell completions.