### PR TITLE
Add --run-in-shell option to `es run`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use crate::{
     error::ExitCodeError,
     shell::{Shell, ShellKind},
 };
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use atty::Stream;
 use clap::{Parser, Subcommand};
 use log::{error, info, LevelFilter};
@@ -275,7 +275,8 @@ impl Executor {
         let status = Command::new(&command.program)
             .args(&command.arguments)
             .envs(environment.iter_unmasked())
-            .status()?;
+            .status()
+            .context(command)?;
 
         if status.success() {
             Ok(())

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -103,13 +103,18 @@ impl Shell {
         }
     }
 
-    /// Execute a command in this shell, and return the stdout value.
-    pub fn execute_shell(&self, command: &str) -> anyhow::Result<String> {
+    /// Get a NativeCommand to execute the given command in this shell
+    pub fn get_shell_command(&self, command: &str) -> NativeCommand {
         // Use the full shell path if we have it. Otherwise, just pass the
         // shell name and hope it's in PATH
         let shell_executable =
             self.path.clone().unwrap_or_else(|| self.kind.to_string());
-        Self::execute_native((shell_executable, ["-c", command]))
+        (shell_executable, ["-c", command]).into()
+    }
+
+    /// Execute a command in this shell, and return the stdout value.
+    pub fn execute_shell(&self, command: &str) -> anyhow::Result<String> {
+        Self::execute_native(self.get_shell_command(command))
     }
 
     /// Execute a program with the given arguments, and return the stdout value.

--- a/tests/test_run.rs
+++ b/tests/test_run.rs
@@ -8,7 +8,7 @@ use rstest_reuse::{self, *};
 
 /// Test that `es run` exports variables only for the single command
 #[apply(all_shells)]
-fn test_subcommand_run(shell_kind: &str) {
+fn test_subcommand_run_native(shell_kind: &str) {
     // We need ||true because printenv fails when given unknown vars
     let printenv_command = "printenv VARIABLE1 VARIABLE2 VARIABLE3 VARIABLE4 \
         FILE_VARIABLE1 FILE_VARIABLE2";
@@ -25,4 +25,25 @@ fn test_subcommand_run(shell_kind: &str) {
     .assert()
     .success()
     .stdout("abc\ndef\nghi\njkl\n123\n456\nEmpty:\n");
+}
+
+/// Test that `es run --run-in-shell` executes the command within a subshell
+#[apply(all_shells)]
+fn test_subcommand_run_shell(shell_kind: &str) {
+    // We need ||true because printenv fails when given unknown vars
+    let echo_command = "echo '$VARIABLE1' '$VARIABLE2' '$VARIABLE3' \
+        '$VARIABLE4' '$FILE_VARIABLE1' '$FILE_VARIABLE2'";
+    execute_script(
+        &format!(
+            "
+            es run --run-in-shell integration-tests p1 -- {echo_command}
+            echo Empty: $VARIABLE1
+            "
+        ),
+        shell_kind,
+        true,
+    )
+    .assert()
+    .success()
+    .stdout("abc def ghi jkl 123 456\nEmpty:\n");
 }


### PR DESCRIPTION
This makes it easier to use aliases and other shell features inside `es run` statements.

Before:

```
es run server dev -- fish -c fancy-alias
```

After:

```
es run -r server dev -- fancy-alias
```