### PR TITLE
Remove intra-profile merging

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -411,12 +411,14 @@ The `dev` profile excludes the `DB_PASSWORD` variable. Beware though, whenever s
 
 ### Cascading configs
 
-On every execution, env-select will scan the current directory for a file called `.env-select.toml` and parse it for a config. In addition to that, it will walk up the directory tree and check each ancestor directory tree for the same file. If multiple files are found, the results will be merged together, with **lower config files having higher precedence**. For example, if we execute `es set SERVICE1` in `~/code/`:
+On every execution, env-select will scan the current directory for a file called `.env-select.toml` and parse it for a config. In addition to that, it will walk up the directory tree and check each ancestor directory tree for the same file. If multiple files are found, the results will be merged together, **down to the profile level only**. Lower config files having higher precedence. For example, if we execute `es set SERVICE1` in `~/code/`:
 
 ```toml
 # ~/code/.env-select.toml
 [applications.server.profiles.dev]
 variables = {SERVICE1 = "secret-dev-server", SERVICE2 = "another-secret-dev-server"}
+[applications.server.profiles.stg]
+variables = {SERVICE1 = "secret-stg-server", SERVICE2 = "another-secret-stg-server"}
 ```
 
 ```toml
@@ -431,12 +433,16 @@ then our resulting config, at execution time, will look like:
 
 ```toml
 # Note: this config never exists in the file system, only in memory during program execution
+
 # From ~/code/.env-select.toml (higher precedence)
 [applications.server.profiles.dev]
-variables = {SERVICE1 = "secret-dev-server", SERVICE2 = "another-secret-dev-server"}
-# From ~/.env-select.toml (no value in ~/code/.env-select.toml)
+variables = {SERVICE1 = "dev", SERVICE2 = "also-dev"}
 [applications.server.profiles.prd]
 variables = {SERVICE1 = "prd", SERVICE2 = "also-prd"}
+
+# From ~/.env-select.toml (no value in ~/code/.env-select.toml)
+[applications.server.profiles.stg]
+variables = {SERVICE1 = "secret-stg-server", SERVICE2 = "another-secret-stg-server"}
 ```
 
 To see where env-select is loading configs from, and how they are being merged together, run the command with the `--verbose` (or `-v`) flag.

--- a/src/config/merge.rs
+++ b/src/config/merge.rs
@@ -1,50 +1,61 @@
-use super::{Application, Config, Profile};
-use indexmap::{map::Entry, IndexMap, IndexSet};
-use std::hash::Hash;
+use super::Config;
+use crate::config::ProfileReference;
+use indexmap::{map::Entry, IndexMap};
+use log::warn;
+use std::{hash::Hash, path::Path};
 
-/// Indicates that two values of this type can be merged together.
-pub trait Merge {
-    /// Merge another value into this one. The "other" value **will take
-    /// precedence** over this one, meaning conflicting values from the incoming
-    /// will overwrite.
-    fn merge(&mut self, other: Self);
-}
-
-impl Merge for Config {
-    fn merge(&mut self, other: Self) {
-        self.applications.merge(other.applications);
+impl Config {
+    /// Merge another config into this one. This is similar to inheritance, but
+    /// simpler. This is used only for merging multiple config files together.
+    /// We only merge down to the profile level. If the same profile is defined
+    /// in both files, our version will be used and the other will be thrown
+    /// out.
+    pub(super) fn merge(&mut self, other: Self, other_path: &Path) {
+        // Merge applications together. It would've been nice to use the trait
+        // pattern like Qualify and Inherit, but it turns out it complicates
+        // this a lot because of the need for context passing.
+        merge_map(
+            &mut self.applications,
+            other.applications,
+            |application_name, self_application, other_application| {
+                // Merge profiles together
+                merge_map(
+                    &mut self_application.profiles,
+                    other_application.profiles,
+                    // If two profiles conflict, just print a warning
+                    |profile_name, _, _| {
+                        // ProfileReference gives us consistent formatting
+                        let reference: ProfileReference =
+                            (application_name.clone(), profile_name).into();
+                        warn!(
+                            "Duplicate definition for profile `{reference}`. \
+                            Definition from `{}` will not be used.",
+                            other_path.display()
+                        )
+                    },
+                )
+            },
+        );
     }
 }
 
-impl Merge for Application {
-    fn merge(&mut self, other: Self) {
-        self.profiles.merge(other.profiles)
-    }
-}
-
-impl Merge for Profile {
-    fn merge(&mut self, other: Self) {
-        // Incoming entries take priority over ours
-        // TODO - should we really be merging profiles?
-        self.extends.merge(other.extends);
-        self.variables.extend(other.variables.into_iter());
-    }
-}
-
-impl<T: Eq + Hash> Merge for IndexSet<T> {
-    fn merge(&mut self, other: Self) {
-        self.extend(other)
-    }
-}
-
-impl<K: Eq + Hash, V: Merge> Merge for IndexMap<K, V> {
-    fn merge(&mut self, other: Self) {
-        for (k, other_v) in other {
-            match self.entry(k) {
-                Entry::Occupied(mut entry) => entry.get_mut().merge(other_v),
-                Entry::Vacant(entry) => {
-                    entry.insert(other_v);
-                }
+/// Merge two maps together. If there's a conflict between two entries, call the
+/// given function, which can trigger a recursive sub-merge if it wants.
+fn merge_map<K: Clone + Eq + Hash, V>(
+    alpha: &mut IndexMap<K, V>,
+    beta: IndexMap<K, V>,
+    on_conflict: impl Fn(K, &mut V, V),
+) {
+    for (k, other_v) in beta {
+        match alpha.entry(k) {
+            Entry::Occupied(mut entry) => {
+                // The clone is ugly, but it skirts lifetime issues. Turns out
+                // to be necessary anyway since we need an owned Name to make
+                // a ProfileReference above
+                on_conflict(entry.key().clone(), entry.get_mut(), other_v)
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(other_v);
             }
         }
     }
@@ -52,192 +63,52 @@ impl<K: Eq + Hash, V: Merge> Merge for IndexMap<K, V> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::config::{
         tests::{config, literal, map, set},
         Profile,
     };
-    use indexmap::{IndexMap, IndexSet};
     use pretty_assertions::assert_eq;
-
-    #[test]
-    fn test_merge_map() {
-        let mut map1: IndexMap<String, IndexSet<&str>> =
-            map([("a", set(["1"])), ("b", set(["2"]))]);
-        let map2 = map([("a", set(["3"])), ("c", set(["4"]))]);
-        map1.merge(map2);
-        assert_eq!(
-            map1,
-            map(
-                [("a", set(["1", "3"])), ("b", set(["2"])), ("c", set(["4"])),]
-            )
-        );
-    }
+    use std::path::PathBuf;
 
     #[test]
     fn test_merge_config() {
-        let mut cfg1 = config(vec![
-            (
-                "app1",
-                vec![
-                    (
-                        "prof1",
-                        Profile {
-                            extends: set(["prof2"]),
-                            pre_export: vec![],
-                            post_export: vec![],
-                            variables: map([
-                                // Gets overwritten
-                                ("VAR1", literal("val1")),
-                                ("VAR2", literal("val2")),
-                            ]),
-                        },
-                    ),
-                    // No conflict
-                    (
-                        "prof2",
-                        Profile {
-                            extends: set([]),
-                            pre_export: vec![],
-                            post_export: vec![],
-                            variables: map([
-                                ("VAR1", literal("val11")),
-                                ("VAR2", literal("val22")),
-                            ]),
-                        },
-                    ),
-                ],
-            ),
-            // No conflict
-            (
-                "app2",
-                vec![(
-                    "prof1",
-                    Profile {
-                        extends: set([]),
-                        pre_export: vec![],
-                        post_export: vec![],
-                        variables: map([("VAR1", literal("val1"))]),
-                    },
-                )],
-            ),
+        let alpha_profile = Profile {
+            extends: set([]),
+            pre_export: vec![],
+            post_export: vec![],
+            variables: map([("VARIABLE1", literal("alpha"))]),
+        };
+        let beta_profile = Profile {
+            extends: set([]),
+            pre_export: vec![],
+            post_export: vec![],
+            variables: map([("VARIABLE1", literal("beta"))]),
+        };
+        let mut alpha_config = config(vec![(
+            "app1",
+            vec![
+                ("no_conflict", alpha_profile.clone()),
+                ("conflict", alpha_profile.clone()),
+            ],
+        )]);
+        let beta_config = config(vec![
+            ("app1", vec![("conflict", beta_profile.clone())]),
+            // Different app - no conflict
+            ("app2", vec![("no_conflict", beta_profile.clone())]),
         ]);
-        let cfg2 = config(vec![
-            // Merged into existing
-            (
-                "app1",
-                vec![
-                    (
-                        "prof1",
-                        Profile {
-                            extends: set(["prof3"]),
-                            pre_export: vec![],
-                            post_export: vec![],
-                            variables: map([
-                                // Overwrites
-                                ("VAR1", literal("val7")),
-                            ]),
-                        },
-                    ),
-                    // No conflict
-                    (
-                        "prof3",
-                        Profile {
-                            extends: set([]),
-                            pre_export: vec![],
-                            post_export: vec![],
-                            variables: map([
-                                ("VAR1", literal("val111")),
-                                ("VAR2", literal("val222")),
-                            ]),
-                        },
-                    ),
-                ],
-            ),
-            // No conflict
-            (
-                "app3",
-                vec![(
-                    "prof1",
-                    Profile {
-                        extends: set([]),
-                        pre_export: vec![],
-                        post_export: vec![],
-                        variables: map([("VAR1", literal("val11"))]),
-                    },
-                )],
-            ),
-        ]);
-        cfg1.merge(cfg2);
+        alpha_config.merge(beta_config, &PathBuf::new());
         assert_eq!(
-            cfg1,
+            alpha_config,
             config(vec![
                 (
                     "app1",
                     vec![
-                        (
-                            "prof1",
-                            Profile {
-                                extends: set(["prof2", "prof3"]),
-                                pre_export: vec![],
-                                post_export: vec![],
-                                variables: map([
-                                    ("VAR1", literal("val7")),
-                                    ("VAR2", literal("val2")),
-                                ])
-                            }
-                        ),
-                        (
-                            "prof2",
-                            Profile {
-                                extends: set([]),
-                                pre_export: vec![],
-                                post_export: vec![],
-                                variables: map([
-                                    ("VAR1", literal("val11")),
-                                    ("VAR2", literal("val22"))
-                                ])
-                            }
-                        ),
-                        (
-                            "prof3",
-                            Profile {
-                                extends: set([]),
-                                pre_export: vec![],
-                                post_export: vec![],
-                                variables: map([
-                                    ("VAR1", literal("val111")),
-                                    ("VAR2", literal("val222")),
-                                ])
-                            }
-                        ),
-                    ]
+                        ("no_conflict", alpha_profile.clone()),
+                        ("conflict", alpha_profile)
+                    ],
                 ),
-                (
-                    "app2",
-                    vec![(
-                        "prof1",
-                        Profile {
-                            extends: set([]),
-                            pre_export: vec![],
-                            post_export: vec![],
-                            variables: map([("VAR1", literal("val1"))])
-                        },
-                    )]
-                ),
-                (
-                    "app3",
-                    vec![(
-                        "prof1",
-                        Profile {
-                            extends: set([]),
-                            pre_export: vec![],
-                            post_export: vec![],
-                            variables: map([("VAR1", literal("val11"))])
-                        },
-                    )]
-                ),
-            ]),
+                ("app2", vec![("no_conflict", beta_profile)])
+            ])
         );
     }
 }


### PR DESCRIPTION
This simplifies merging a lot, and lines up more with the behavior I would expect. Merging two separate config files should essentially just mean concating them together, and taking the lower file when there's a conflict.