### PR TITLE
Remove native commands from value sources and side effects

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -125,14 +125,7 @@ dev also-dev
 
 ```
 
-`--` is required to delineate the arguments handled by `es` from the command being executed. The executed command is called directly, _not_ executed in a shell. To access shell features in the executed command use `--run-in-shell` (or `-r`):
-
-```sh
-> es run -r server dev -- 'echo $SERVICE1 | cat -'
-dev
-```
-
-Make sure to use **single** quotes in those case, otherwise `$SERVICE1` will be evaluted by your shell _before_ executing env-select.
+`--` is required to delineate the arguments handled by `es` from the command being executed. The executed command is executed in your shell, so you can access shell features such as pipes and aliases.
 
 ### Dynamic Values
 
@@ -142,19 +135,12 @@ You can define variables whose values are provided dynamically, by specifying a 
 [applications.db.profiles.dev.variables]
 DATABASE = "dev"
 DB_USER = "root"
-DB_PASSWORD = {type = "command", command = ["curl", "https://www.random.org/strings/?format=plain&len=10&num=1&loweralpha=on"], sensitive = true}
+DB_PASSWORD = {type = "command", command = "curl https://www.random.org/strings/?format=plain&len=10&num=1&loweralpha=on", sensitive = true}
 ```
 
 When the `dev` profile is selected for the `db` app, the `DB_PASSWORD` value will be loaded from the file `password.txt`. The `sensitive` field is an _optional_ field that will mask the value in informational logging.
 
-By default, the program (the first argument in the list) is executed directly by env-select, and passed the rest of the list as arguments. If you want to execute a command in your shell, you can use the `shell` type instead. This will give access to shell features such as aliases and pipes. For example:
-
-```toml
-[applications.db.profiles.dev.variables]
-DATABASE = "dev"
-DB_USER = "root"
-DB_PASSWORD = {type = "shell", command = "echo password | base64", sensitive = true}
-```
+The command is executed in the shell detected by env-select as your default (or the shell passed with `--shell`).
 
 ### Multiple Values from a Single Source
 
@@ -547,13 +533,10 @@ GREETING = "hello"
 
 # Literal expanded form - generally not needed
 [applications.example.profiles.literal.variables]
-GREETING = {type = "literal", value = "hello"},
+GREETING = {type = "literal", value = "hello"}
 
 [applications.example.profiles.command.variables]
-GREETING = {type = "command", command = ["echo", "hello"]}, # Native command
-
-[applications.example.profiles.shell.variables]
-GREETING = {type = "shell", command = "echo hello | cat -"}, # Shell command
+GREETING = {type = "command", command = "echo hello"}
 ```
 
 #### Value Source Types
@@ -562,8 +545,7 @@ GREETING = {type = "shell", command = "echo hello | cat -"}, # Shell command
 | ----------------- | ---------------------------------------- |
 | `literal`         | Literal static value                     |
 | `file`            | Load values from a file                  |
-| `command`         | Execute an external program by name/path |
-| `shell`           | Execute a shell command                  |
+| `command`         | Execute a shell command                  |
 | `kubernetes`      | Execute a command in a Kubernetes pod    |
 
 #### Common Fields
@@ -583,8 +565,7 @@ Each source type has its own set of available fields:
 | ----------------- | -------------- | --------------- | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `literal`         | `value`        | `string`        | **Required** | Static value to export                                                                                                                                                            |
 | `file`            | `path`         | `string`        | **Required** | Path to the file, relative to **the config file in which this is defined**                                                                                                        |
-| `command`         | `command`      | `array[string]` | **Required** | Command to execute, as `[program, ...arguments]`; the output of the command will be exported                                                                                      |
-| `shell`           | `command`      | `string`        | **Required** | Command to execute in a subshell; the output of the command will be exported                                                                                                      |
+| `command`         | `command`      | `string`        | **Required** | Command to execute in a subshell; the output of the command will be exported                                                                                                      |
 | `kubernetes`      | `command`      | `array[string]` | **Required** | Command to execute in the pod, as `[program, ...arguments]`; the output of the command will be exported                                                                           |
 | `kubernetes`      | `pod_selector` | `string`        | **Required** | Label query used to find the target pod. Must match exactly one pod. See [kubectl docs](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) for more info. |
 | `kubernetes`      | `namespace`    | `string`        | `null`       | Namespace in which to search for the target pod. If omitted, `kubectl` will use the current context namespace.                                                                    |
@@ -599,7 +580,3 @@ env-select supports the following shells:
 - fish
 
 If you use a different shell and would like support for it, please open an issue and I'll see what I can do!
-
-```
-
-```

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,5 +1,7 @@
 use crate::{
-    config::ShellCommand, environment::Environment, execute::Executable,
+    config::ShellCommand,
+    environment::Environment,
+    execute::{Executable, IntoExecutable},
 };
 use anyhow::anyhow;
 use clap::ValueEnum;
@@ -133,7 +135,7 @@ impl Shell {
         // the shell name and hope it's in PATH
         let shell_program =
             self.path.clone().unwrap_or_else(|| self.kind.to_string());
-        (shell_program, ["-c", command]).into()
+        (shell_program, ["-c", command]).executable()
     }
 }
 

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,9 +1,8 @@
 //! Utilities for tests!
 
 use crate::config::{
-    Application, Config, Name, NativeCommand, Profile, ProfileReference,
-    SideEffect, SideEffectCommand, ValueSource, ValueSourceInner,
-    ValueSourceKind,
+    Application, Config, Name, Profile, ProfileReference, SideEffect,
+    ValueSource, ValueSourceInner, ValueSourceKind,
 };
 use indexmap::{IndexMap, IndexSet};
 use rstest_reuse::{self, *};
@@ -28,27 +27,6 @@ impl From<ValueSourceKind> for ValueSource {
             sensitive: false,
             multiple: false,
         })
-    }
-}
-
-/// Shorthand for creating a native side effect
-impl<const N: usize> From<[&str; N]> for SideEffectCommand {
-    fn from(value: [&str; N]) -> Self {
-        Self::Native(
-            value
-                .into_iter()
-                .map(String::from)
-                .collect::<Vec<String>>()
-                .try_into()
-                .unwrap(),
-        )
-    }
-}
-
-/// Shorthand for creating a shell side effect
-impl From<&str> for SideEffectCommand {
-    fn from(value: &str) -> Self {
-        Self::Shell(value.into())
     }
 }
 
@@ -115,36 +93,19 @@ pub fn file(path: impl AsRef<Path>) -> ValueSource {
     .into()
 }
 
-/// Helper to create a native command
-pub fn native<const N: usize>(
-    program: &str,
-    arguments: [&str; N],
-) -> ValueSource {
-    ValueSourceKind::NativeCommand {
-        command: NativeCommand {
-            program: program.into(),
-            arguments: arguments.into_iter().map(String::from).collect(),
-        },
-    }
-    .into()
-}
-
 /// Helper to create a shell command
-pub fn shell(command: &str) -> ValueSource {
-    ValueSourceKind::ShellCommand {
-        command: command.into(),
+pub fn command(command: &str) -> ValueSource {
+    ValueSourceKind::Command {
+        command: command.to_owned().into(),
     }
     .into()
 }
 
 /// Create a side effect from (setup, teardown)
-pub fn side_effect<S: Into<SideEffectCommand>, T: Into<SideEffectCommand>>(
-    setup: S,
-    teardown: T,
-) -> SideEffect {
+pub fn side_effect(setup: &str, teardown: &str) -> SideEffect {
     SideEffect {
-        setup: Some(setup.into()),
-        teardown: Some(teardown.into()),
+        setup: Some(setup.to_owned().into()),
+        teardown: Some(teardown.to_owned().into()),
     }
 }
 

--- a/tests/.env-select.toml
+++ b/tests/.env-select.toml
@@ -11,6 +11,5 @@ post_export = [
 ]
 variables.VARIABLE1 = "abc"
 variables.VARIABLE2 = "def"
-variables.VARIABLE3 = {type = "command", command = ["echo", "ghi"]}
-variables.VARIABLE4 = {type = "shell", command = "echo jkl | cat -"}
+variables.VARIABLE3 = {type = "command", command = "echo ghi | cat -"}
 variables.file = {type = "file", path = "vars.env", multiple = true}

--- a/tests/test_run.rs
+++ b/tests/test_run.rs
@@ -6,55 +6,17 @@ use common::*;
 use rstest::rstest;
 use rstest_reuse::{self, *};
 
-/// Test that `es run` exports variables only for the single command
+/// Test `es run` executes the command within a subshell, and the variables
+/// don't leak outside that subprocess
 #[apply(all_shells)]
-fn test_subcommand_run_native(shell_kind: &str) {
-    // We need ||true because printenv fails when given unknown vars
-    let printenv_command = "printenv VARIABLE1 VARIABLE2 VARIABLE3 VARIABLE4 \
-        FILE_VARIABLE1 FILE_VARIABLE2";
-    execute_script(
-        &format!(
-            "
-            es run integration-tests p1 -- {printenv_command}
-            echo Empty: $VARIABLE1
-            "
-        ),
-        shell_kind,
-        true,
-    )
-    .assert()
-    .success()
-    .stdout(
-        "pre setup 1
-pre setup 2
-post setup 1 abc
-post setup 2 abc
-abc
-def
-ghi
-jkl
-123
-456
-post teardown 2 abc
-post teardown 1 abc
-pre teardown 2
-pre teardown 1
-Empty:
-",
-    )
-    .stderr("");
-}
-
-/// Test that `es run --run-in-shell` executes the command within a subshell
-#[apply(all_shells)]
-fn test_subcommand_run_shell(shell_kind: &str) {
+fn test_subcommand_run(shell_kind: &str) {
     // We need ||true because printenv fails when given unknown vars
     let echo_command = "echo '$VARIABLE1' '$VARIABLE2' '$VARIABLE3' \
         '$VARIABLE4' '$FILE_VARIABLE1' '$FILE_VARIABLE2'";
     execute_script(
         &format!(
             "
-            es run --run-in-shell integration-tests p1 -- {echo_command}
+            es run integration-tests p1 -- {echo_command}
             echo Empty: $VARIABLE1
             "
         ),
@@ -68,7 +30,7 @@ fn test_subcommand_run_shell(shell_kind: &str) {
 pre setup 2
 post setup 1 abc
 post setup 2 abc
-abc def ghi jkl 123 456
+abc def ghi 123 456
 post teardown 2 abc
 post teardown 1 abc
 pre teardown 2

--- a/tests/test_set.rs
+++ b/tests/test_set.rs
@@ -38,10 +38,9 @@ The following variables will be set:
 VARIABLE1 = abc
 VARIABLE2 = def
 VARIABLE3 = ghi
-VARIABLE4 = jkl
 FILE_VARIABLE1 = 123
 FILE_VARIABLE2 = 456
-abc def ghi jkl 123 456",
+abc def ghi 123 456",
     )
     .stderr("");
 }


### PR DESCRIPTION
In hindsight, I don't really see a use case for using native commands. It makes sense in the context of executing commands from code, but since the point of env-select is to be a shell extension, we should just assume everything should run in code.