### PR TITLE
Add `cwd` option to command value sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,21 +71,21 @@ Because env-select modifies your shell environment, it requires a wrapper functi
 #### Bash
 
 ```sh
-echo 'eval "$(env-select init)"' >> ~/.bashrc
+echo 'eval "$(env-select --shell bash init)"' >> ~/.bashrc
 source ~/.bashrc # Run this in every existing shell
 ```
 
 #### Zsh
 
 ```sh
-echo 'source <(env-select init)' >> ~/.zshrc
+echo 'source <(env-select --shell zsh init)' >> ~/.zshrc
 source ~/.zshrc # Run this in every existing shell
 ```
 
 #### Fish
 
 ```sh
-echo 'env-select init | source' >> ~/.config/fish/config.fish
+echo 'env-select --shell fish init | source' >> ~/.config/fish/config.fish
 source ~/.config/fish/config.fish # Run this in every existing shell
 ```
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -338,7 +338,7 @@ Side effects are executed in their order of definition for setup, and the **reve
 
 #### Side Effect Inheritance
 
-Inherited side effects are executed *before* side effects defined in the selected profile during setup, and therefore *after* during teardown. For profiles with multiple parents, the *left-most* parent's side effects will execute first.
+Inherited side effects are executed _before_ side effects defined in the selected profile during setup, and therefore _after_ during teardown. For profiles with multiple parents, the _left-most_ parent's side effects will execute first.
 
 An example of a config with inheritance:
 
@@ -541,12 +541,12 @@ GREETING = {type = "command", command = "echo hello"}
 
 #### Value Source Types
 
-| Value Source Type | Description                              |
-| ----------------- | ---------------------------------------- |
-| `literal`         | Literal static value                     |
-| `file`            | Load values from a file                  |
-| `command`         | Execute a shell command                  |
-| `kubernetes`      | Execute a command in a Kubernetes pod    |
+| Value Source Type | Description                           |
+| ----------------- | ------------------------------------- |
+| `literal`         | Literal static value                  |
+| `file`            | Load values from a file               |
+| `command`         | Execute a shell command               |
+| `kubernetes`      | Execute a command in a Kubernetes pod |
 
 #### Common Fields
 
@@ -561,15 +561,16 @@ All value sources support the following common fields:
 
 Each source type has its own set of available fields:
 
-| Value Source Type | Field          | Type            | Default      | Description                                                                                                                                                                       |
-| ----------------- | -------------- | --------------- | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `literal`         | `value`        | `string`        | **Required** | Static value to export                                                                                                                                                            |
-| `file`            | `path`         | `string`        | **Required** | Path to the file, relative to **the config file in which this is defined**                                                                                                        |
-| `command`         | `command`      | `string`        | **Required** | Command to execute in a subshell; the output of the command will be exported                                                                                                      |
-| `kubernetes`      | `command`      | `array[string]` | **Required** | Command to execute in the pod, as `[program, ...arguments]`; the output of the command will be exported                                                                           |
-| `kubernetes`      | `pod_selector` | `string`        | **Required** | Label query used to find the target pod. Must match exactly one pod. See [kubectl docs](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) for more info. |
-| `kubernetes`      | `namespace`    | `string`        | `null`       | Namespace in which to search for the target pod. If omitted, `kubectl` will use the current context namespace.                                                                    |
-| `kubernetes`      | `container`    | `string`        | `null`       | Container within the target pod to execute in. If omitted, `kubectl` will use the default defined by the `kubectl.kubernetes.io/default-container` annotation.                    |
+| Value Source Type | Field          | Type            | Default      | Description                                                                                                                                                                                 |
+| ----------------- | -------------- | --------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `literal`         | `value`        | `string`        | **Required** | Static value to export                                                                                                                                                                      |
+| `file`            | `path`         | `string`        | **Required** | Path to the file, relative to **the config file in which this is defined**                                                                                                                  |
+| `command`         | `command`      | `string`        | **Required** | Command to execute in a subshell; the output of the command will be exported                                                                                                                |
+| `command`         | `cwd`          | `string`        | `null`       | Directory from which to execute the command. Defaults to the directory from which `es` was invoked. Paths will be relative to the `.env-select.toml` file in which this command is defined. |
+| `kubernetes`      | `command`      | `array[string]` | **Required** | Command to execute in the pod, as `[program, ...arguments]`; the output of the command will be exported                                                                                     |
+| `kubernetes`      | `pod_selector` | `string`        | **Required** | Label query used to find the target pod. Must match exactly one pod. See [kubectl docs](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) for more info.           |
+| `kubernetes`      | `namespace`    | `string`        | `null`       | Namespace in which to search for the target pod. If omitted, `kubectl` will use the current context namespace.                                                                              |
+| `kubernetes`      | `container`    | `string`        | `null`       | Container within the target pod to execute in. If omitted, `kubectl` will use the default defined by the `kubectl.kubernetes.io/default-container` annotation.                              |
 
 ## Shell Support
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -299,12 +299,13 @@ fn test_parse_side_effects() {
 
 #[test]
 fn test_parse_shell_command() {
+    // Without cwd
     assert_tokens(
         &command("echo test").0.kind,
         &[
             Token::Struct {
                 name: "ValueSourceKind",
-                len: 2,
+                len: 3,
             },
             Token::Str("type"),
             Token::Str("command"),
@@ -313,6 +314,30 @@ fn test_parse_shell_command() {
                 name: "ShellCommand",
             },
             Token::Str("echo test"),
+            Token::Str("cwd"),
+            Token::None,
+            Token::StructEnd,
+        ],
+    );
+
+    // With cwd
+    assert_tokens(
+        &command("echo test").cwd("/root").0.kind,
+        &[
+            Token::Struct {
+                name: "ValueSourceKind",
+                len: 3,
+            },
+            Token::Str("type"),
+            Token::Str("command"),
+            Token::Str("command"),
+            Token::NewtypeStruct {
+                name: "ShellCommand",
+            },
+            Token::Str("echo test"),
+            Token::Str("cwd"),
+            Token::Some,
+            Token::Str("/root"),
             Token::StructEnd,
         ],
     );

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -41,6 +41,16 @@ impl ValueSource {
         self.0.multiple = true;
         self
     }
+
+    pub fn cwd(mut self, cwd: &str) -> Self {
+        match &mut self.0.kind {
+            ValueSourceKind::Command { cwd: dest, .. } => {
+                *dest = Some(cwd.into())
+            }
+            _ => unimplemented!(),
+        }
+        self
+    }
 }
 
 /// Helper to create a full config, from a mapping of applications and profiles
@@ -97,6 +107,7 @@ pub fn file(path: impl AsRef<Path>) -> ValueSource {
 pub fn command(command: &str) -> ValueSource {
     ValueSourceKind::Command {
         command: command.to_owned().into(),
+        cwd: None,
     }
     .into()
 }


### PR DESCRIPTION
Allows executing commands from a particular directory, relative to the config file. By default it executes from the user's cwd (the current behavior). It might seem intuitive to execute from the fixed config directory by default, but it's possible that using the dynamic current dir is desired behavior, and there's no easy way to do that if the default is the config dir. You can easily get config dir now with `cwd = "."`