### PR TITLE
Remove kubernetes value source

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Easily switch between predefined values for arbitrary environment variables Feat
 
 - Interative prompts to select between variable profiles
 - Cascading config system, allowing for system and repo-level value definitions
-- Grab values dynamically via local commands or Kubernetes pods
+- Grab values dynamically via shell commands
 - Modify your shell environment with `es set`, or run a one-off command in a modified environment with `es run`
 - Re-use common variables between profiles with inheritance
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -210,42 +210,6 @@ In this scenario, `SERVICE1` will be loaded from `~/code/service1.txt` while `SE
 
 This value source combines well with the `multiple` field to load `.env` files. [See here](#multiple-values-from-a-single-source).
 
-### Load Values from Kubernetes
-
-Ever had a secret in a Kubernetes pod that you want to fetch easily? The `kubernetes` value source lets you run any command in a kubernetes pod.
-
-```toml
-[applications.db.profiles.dev.variables]
-DATABASE = "dev"
-DB_USER = "root"
-DB_PASSWORD = {type = "kubernetes", namespace = "development", pod_selector = "app=api", command = ["printenv", "DB_PASSWORD"]}
-
-[applications.db.profiles.prd.variables]
-DATABASE = "prd"
-DB_USER = "root"
-DB_PASSWORD = {type = "kubernetes", namespace = "production", pod_selector = "app=api", command = ["printenv", "DB_PASSWORD"]}
-```
-
-`printenv` can be used to easily access environment variables, but you can execute any command you want in the pod. To access shell features in the pod, you'll need to execute under a shell. For example:
-
-```
-command = ["sh", "-c", "env | grep DB_PASSWORD | sed -E 's/.+=(.+)/\1/'"]
-```
-
-You can combine this with the `multiple = true` flag to fetch multiple values at once:
-
-```toml
-[applications.db.profiles.dev.variables]
-DATABASE = "dev"
-# The `creds` key is *not* significant here - you can name it anything you want
-[applications.db.profiles.dev.variables.creds]
-type = "kubernetes"
-namespace = "development"
-pod_selector = "app=api"
-command = ["sh", "-c", "printenv | grep -E '^(DB_USER|DB_PASSWORD)='"]
-multiple = true
-```
-
 ### PATH Variable
 
 If you want to modify the PATH variable, typically you just want to add to it, rather than replace it. Env-select will do this automatically, if the variable has the name `PATH`.
@@ -541,12 +505,11 @@ GREETING = {type = "command", command = "echo hello"}
 
 #### Value Source Types
 
-| Value Source Type | Description                           |
-| ----------------- | ------------------------------------- |
-| `literal`         | Literal static value                  |
-| `file`            | Load values from a file               |
-| `command`         | Execute a shell command               |
-| `kubernetes`      | Execute a command in a Kubernetes pod |
+| Value Source Type | Description             |
+| ----------------- | ----------------------- |
+| `literal`         | Literal static value    |
+| `file`            | Load values from a file |
+| `command`         | Execute a shell command |
 
 #### Common Fields
 
@@ -561,16 +524,12 @@ All value sources support the following common fields:
 
 Each source type has its own set of available fields:
 
-| Value Source Type | Field          | Type            | Default      | Description                                                                                                                                                                                 |
-| ----------------- | -------------- | --------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `literal`         | `value`        | `string`        | **Required** | Static value to export                                                                                                                                                                      |
-| `file`            | `path`         | `string`        | **Required** | Path to the file, relative to **the config file in which this is defined**                                                                                                                  |
-| `command`         | `command`      | `string`        | **Required** | Command to execute in a subshell; the output of the command will be exported                                                                                                                |
-| `command`         | `cwd`          | `string`        | `null`       | Directory from which to execute the command. Defaults to the directory from which `es` was invoked. Paths will be relative to the `.env-select.toml` file in which this command is defined. |
-| `kubernetes`      | `command`      | `array[string]` | **Required** | Command to execute in the pod, as `[program, ...arguments]`; the output of the command will be exported                                                                                     |
-| `kubernetes`      | `pod_selector` | `string`        | **Required** | Label query used to find the target pod. Must match exactly one pod. See [kubectl docs](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) for more info.           |
-| `kubernetes`      | `namespace`    | `string`        | `null`       | Namespace in which to search for the target pod. If omitted, `kubectl` will use the current context namespace.                                                                              |
-| `kubernetes`      | `container`    | `string`        | `null`       | Container within the target pod to execute in. If omitted, `kubectl` will use the default defined by the `kubectl.kubernetes.io/default-container` annotation.                              |
+| Value Source Type | Field     | Type     | Default      | Description                                                                                                                                                                                 |
+| ----------------- | --------- | -------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `literal`         | `value`   | `string` | **Required** | Static value to export                                                                                                                                                                      |
+| `file`            | `path`    | `string` | **Required** | Path to the file, relative to **the config file in which this is defined**                                                                                                                  |
+| `command`         | `command` | `string` | **Required** | Command to execute in a subshell; the output of the command will be exported                                                                                                                |
+| `command`         | `cwd`     | `string` | `null`       | Directory from which to execute the command. Defaults to the directory from which `es` was invoked. Paths will be relative to the `.env-select.toml` file in which this command is defined. |
 
 ## Shell Support
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -127,22 +127,6 @@ pub enum ValueSourceKind {
         /// If omitted, use inherited cwd. Relative to config file
         cwd: Option<PathBuf>,
     },
-
-    /// Run a command in a kubernetes pod.
-    #[serde(rename = "kubernetes")]
-    KubernetesCommand {
-        /// Command to execute in the pod
-        command: Vec<String>,
-        /// Label query used to find the pod
-        /// https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
-        pod_selector: String,
-        /// Optional namespace to run in. If omitted, use current namespace
-        /// from kubectl context.
-        namespace: Option<String>,
-        /// Optional container to run in. If omitted, use
-        /// `kubectl.kubernetes.io/default-container` annotation.
-        container: Option<String>,
-    },
 }
 
 /// A pair of imperative commands to run. The setup command is run during
@@ -351,23 +335,6 @@ impl Display for ValueSourceInner {
                     }
                     None => write!(f, " (current directory)"),
                 }
-            }
-            ValueSourceKind::KubernetesCommand {
-                command,
-                pod_selector,
-                namespace,
-                container,
-            } => {
-                write!(
-                    f,
-                    "{command:?} (kubernetes {}[{pod_selector}]",
-                    namespace.as_deref().unwrap_or("<current namespace>")
-                )?;
-                if let Some(container) = container {
-                    write!(f, ".{container}")?;
-                }
-                write!(f, ")")?;
-                Ok(())
             }
         }
     }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -3,7 +3,7 @@
 
 use super::*;
 use crate::{
-    config::{Config, Profile, ValueSourceKind},
+    config::{Config, Profile},
     test_util::{command, config, literal, map, set, side_effect},
 };
 use pretty_assertions::assert_eq;
@@ -344,44 +344,6 @@ fn test_parse_shell_command() {
 }
 
 #[test]
-fn test_parse_kubernetes() {
-    assert_tokens(
-        &ValueSourceKind::KubernetesCommand {
-            command: vec!["printenv".to_owned(), "DB_PASSWORD".to_owned()],
-            pod_selector: "app=api".to_owned(),
-            namespace: Some("development".to_owned()),
-            container: Some("main".to_owned()),
-        },
-        &[
-            Token::Struct {
-                name: "ValueSourceKind",
-                len: 5,
-            },
-            Token::Str("type"),
-            Token::Str("kubernetes"),
-            //
-            Token::Str("command"),
-            Token::Seq { len: Some(2) },
-            Token::Str("printenv"),
-            Token::Str("DB_PASSWORD"),
-            Token::SeqEnd,
-            //
-            Token::Str("pod_selector"),
-            Token::Str("app=api"),
-            //
-            Token::Str("namespace"),
-            Token::Some,
-            Token::Str("development"),
-            //
-            Token::Str("container"),
-            Token::Some,
-            Token::Str("main"),
-            Token::StructEnd,
-        ],
-    );
-}
-
-#[test]
 fn test_parse_unknown_type() {
     assert_de_tokens_error::<ValueSource>(
         &[
@@ -391,6 +353,6 @@ fn test_parse_unknown_type() {
             Token::MapEnd,
         ],
         "unknown variant `unknown`, expected one of \
-            `literal`, `file`, `command`, `kubernetes`",
+            `literal`, `file`, `command`",
     )
 }

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -1,6 +1,5 @@
 use crate::{
     config::{Profile, ValueSource, ValueSourceKind},
-    execute::execute_kubernetes,
     shell::Shell,
 };
 use anyhow::{anyhow, Context};
@@ -76,19 +75,6 @@ impl Environment {
                 }
                 executable.check_output()?
             }
-
-            // Run a program+args in a kubernetes pod/container
-            ValueSourceKind::KubernetesCommand {
-                command,
-                pod_selector: pod_filter,
-                namespace,
-                container,
-            } => execute_kubernetes(
-                &command,
-                &pod_filter,
-                namespace.as_deref(),
-                container.as_deref(),
-            )?,
         };
 
         if value_source.multiple {
@@ -227,8 +213,6 @@ mod tests {
             Environment(map([("VARIABLE1", resolved_value("test"))]))
         );
     }
-
-    // TODO figure out how to test kubernetes
 
     #[test]
     fn test_resolve_multiple() {


### PR DESCRIPTION
This is actually really easy to achieve with just a bash command. I want to move env-select back toward being more minimal, and this is a good start. I used to think this required two commands (`kubectl get pod` then `kubectl exec`), but turns out you can do it with a single `kubectl exec` by using the deployment name, e.g. `kubectl exec deploy/api -- ...`.

This code was also entirely untested so it's nice we no longer have that issue.