### PR TITLE
Use `es` instead of `env-select` in CLI help output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - [A new website!](https://env-select.lucaspickering.me)
 
+### Changed
+
+- Use `es` instead of `env-select` in CLI help output
+
 ## [0.12.0] - 2024-01-26
 
 ### Changed

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ use std::{
 /// A utility to select between predefined values or sets of environment
 /// variables.
 #[derive(Clone, Debug, Parser)]
-#[clap(author, version, about, long_about = None)]
+#[clap(bin_name = "es", author, version, about, long_about = None)]
 struct Args {
     /// Subcommand to execute
     #[command(subcommand)]


### PR DESCRIPTION
`es` is the command people actually run