### PR TITLE
Load config lazily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased - [ReleaseDate]
+
+### Fixed
+
+- Do not load config for subcommands that don't need it (e.g. `es init`)
+  - This fixes error output showing for invalid configs when it's not relevant
+
 ## 1.1.3 - [2024-02-13]
 
 - Escape single quotes in variable names/values ([#65](https://github.com/LucasPickering/env-select/issues/65))

--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -38,9 +38,10 @@ impl SubcommandTrait for ShowCommand {
                 // Serialize isn't object-safe, so there's no way to return a
                 // dynamic object of what to serialize. That means each branch
                 // has to serialize itself
+                let config = context.config()?;
                 let content = if let Some(application) = application {
                     let application =
-                        context.config.applications.try_get(&application)?;
+                        config.applications.try_get(&application)?;
                     if let Some(profile) = profile {
                         let profile = application.profiles.try_get(&profile)?;
                         toml::to_string(profile)
@@ -49,7 +50,7 @@ impl SubcommandTrait for ShowCommand {
                     }
                 } else {
                     // Print entire config
-                    toml::to_string(&context.config)
+                    toml::to_string(config)
                 }?;
                 println!("{}", content);
             }


### PR DESCRIPTION
Config is loaded on demand now, instead of upfront when the process starts. This means subcommands that don't need it won't load it anymore.